### PR TITLE
verify if grid exists before open remote and internacionalization

### DIFF
--- a/src/main/java/io/github/sefiraat/networks/LocalizationHelper.java
+++ b/src/main/java/io/github/sefiraat/networks/LocalizationHelper.java
@@ -1,0 +1,160 @@
+/**
+ * localization / translation helper
+ * 
+ * based on Supreme simple idea [https://github.com/Slimefun-Addon-Community/Supreme/blob/main/src/main/java/com/github/relativobr/supreme/SupremeLocalization.java]
+ */
+package io.github.sefiraat.networks;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import net.guizhanss.guizhanlib.localization.Localization;
+import net.guizhanss.guizhanlib.minecraft.utils.ChatUtil;
+import net.guizhanss.guizhanlib.utils.StringUtil;
+
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
+
+import io.github.thebusybiscuit.slimefun4.libraries.commons.lang.Validate;
+
+import org.bukkit.entity.Player;
+
+public class LocalizationHelper extends Localization
+{
+	/**
+	 * constructor
+	 */
+	public LocalizationHelper(Networks plugin) {
+		super(plugin);
+	}
+
+	/****
+	 * get the string of key, formating
+	 * 
+	 * @param key
+	 * @param args
+	 * @return
+	 */
+	@ParametersAreNonnullByDefault
+	public @Nonnull
+	String getString(String key, Object... args) {
+		return MessageFormat.format(getString(key), args);
+	}
+
+	/**
+	 * return category name
+	 * 
+	 * @param categoryId
+	 * @return
+	 */
+	public @Nonnull
+	String getCategoryName(@Nonnull String categoryId) {
+		Validate.notNull(categoryId, "Category Id cannot be null");
+
+		return getString("categories." + StringUtil.dehumanize(categoryId).toLowerCase(Locale.ROOT));
+	}
+
+	/**
+	 * get item name
+	 * 
+	 * @param itemId
+	 * @return
+	 */
+	public @Nonnull
+	String getItemName(@Nonnull String itemId) {
+		Validate.notNull(itemId, "Item Id cannot be null");
+
+		return getString("items." + StringUtil.dehumanize(itemId).toLowerCase(Locale.ROOT) + ".name");
+	}
+
+	/***
+	 * get item lore
+	 * 
+	 * @param itemId
+	 * @return
+	 */
+	public @Nonnull
+	String[] getItemLore(@Nonnull String itemId) {
+		Validate.notNull(itemId, "Item Id cannot be null");
+
+		return getStringArray("items." + StringUtil.dehumanize(itemId).toLowerCase(Locale.ROOT) + ".lore");
+	}
+
+	/***
+	 * get item extra/conditional lore
+	 * 
+	 * @param itemId
+	 * @return
+	 */
+	public @Nonnull
+	String[] getItemItemAditionalLore(@Nonnull String itemId) {
+		Validate.notNull(itemId, "Item Id cannot be null");
+
+		return getStringArray("items." + StringUtil.dehumanize(itemId).toLowerCase(Locale.ROOT) + ".aditional_lore");
+	}
+
+	/**
+	 * get research name
+	 * 
+	 * @param researchId
+	 * @return
+	 */
+	public @Nonnull
+	String getResearchName(@Nonnull String researchId) {
+		Validate.notNull(researchId, "Research Id cannot be null");
+
+		return getString("researches." + StringUtil.dehumanize(researchId).toLowerCase(Locale.ROOT));
+	}
+
+	/**
+	 * get messages byy key
+	 * 
+	 * @param p
+	 * @param messageKey
+	 * @param args
+	 */
+	public @Nonnull
+	String getMessage(@Nonnull String messageId) {
+		Validate.notNull(messageId, "Message Id cannot be null");
+
+		return getString("messages." + StringUtil.dehumanize(messageId).toLowerCase(Locale.ROOT));
+	}
+
+
+	/**
+	 * get research description
+	 * 
+	 * @param p
+	 * @param messageKey
+	 * @param args
+	 */
+	@ParametersAreNonnullByDefault
+	public void sendMessage(Player p, String messageKey, Object... args) {
+		Validate.notNull(p, "Player cannot be null");
+		Validate.notNull(messageKey, "Message key cannot be null");
+
+		ChatUtil.send(p, MessageFormat.format(getString("messages." + messageKey), args));
+	}
+
+	/***
+	 * send actionbar message
+	 * 
+	 * @param p
+	 * @param messageKey
+	 * @param args
+	 */
+	@ParametersAreNonnullByDefault
+	public void sendActionbarMessage(Player p, String messageKey, Object... args) {
+		Validate.notNull(p, "Player cannot be null");
+		Validate.notNull(messageKey, "Message key cannot be null");
+
+		String message = MessageFormat.format(getString("messages." + messageKey), args);
+
+		BaseComponent[] components = TextComponent.fromLegacyText(ChatUtil.color(message));
+		p.spigot().sendMessage(ChatMessageType.ACTION_BAR, components);
+	}
+}

--- a/src/main/java/io/github/sefiraat/networks/Networks.java
+++ b/src/main/java/io/github/sefiraat/networks/Networks.java
@@ -11,6 +11,7 @@ import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import net.guizhanss.guizhanlibplugin.updater.GuizhanUpdater;
 import net.guizhanss.slimefun4.utils.WikiUtils;
+import net.guizhanss.guizhanlib.localization.Localization;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.AdvancedPie;
 import org.bukkit.plugin.PluginManager;
@@ -35,6 +36,9 @@ public class Networks extends JavaPlugin implements SlimefunAddon {
     private ListenerManager listenerManager;
     private SupportedPluginManager supportedPluginManager;
 
+    // store localization/translation instance
+    private static LocalizationHelper localization = null;
+
     public Networks() {
         this.username = "SlimefunGuguProject";
         this.repo = "Networks";
@@ -46,8 +50,7 @@ public class Networks extends JavaPlugin implements SlimefunAddon {
         instance = this;
 
         if (!getServer().getPluginManager().isPluginEnabled("GuizhanLibPlugin")) {
-            getLogger().log(Level.SEVERE, "本插件需要 鬼斩前置库插件(GuizhanLibPlugin) 才能运行!");
-            getLogger().log(Level.SEVERE, "从此处下载: https://50l.cc/gzlib");
+            getLogger().log(Level.SEVERE, Networks.getLocalization().getMessage("need_guizhanlib_plugin"));
             getServer().getPluginManager().disablePlugin(this);
             return;
         }
@@ -83,16 +86,30 @@ public class Networks extends JavaPlugin implements SlimefunAddon {
             try {
                 NetheoPlants.setup();
             } catch (NoClassDefFoundError e) {
-                getLogger().severe("你必须更新下界乌托邦才能让网络添加相关功能。");
+                getLogger().severe(Networks.getLocalization().getMessage("need_netheo_plugin_update"));
             }
         }
         if (supportedPluginManager.isSlimeHud()) {
             try {
                 HudCallbacks.setup();
             } catch (NoClassDefFoundError e) {
-                getLogger().severe("你必须更新 SlimeHUD 才能让网络添加相关功能。");
+                getLogger().severe(Networks.getLocalization().getMessage("need_slimehud_plugin_update"));
             }
         }
+    }
+
+    /***
+     * get localization instance
+     * 
+     * @return
+     */
+    public static LocalizationHelper getLocalization() {
+        if (localization == null) {
+            localization = new LocalizationHelper(instance);
+            localization.addLanguage(instance.getConfig().getString("lang"));
+        }
+
+        return localization;
     }
 
     public void setupMetrics() {

--- a/src/main/java/io/github/sefiraat/networks/commands/NetworksMain.java
+++ b/src/main/java/io/github/sefiraat/networks/commands/NetworksMain.java
@@ -1,5 +1,6 @@
 package io.github.sefiraat.networks.commands;
 
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.stackcaches.QuantumCache;
 import io.github.sefiraat.networks.slimefun.NetworkSlimefunItems;
 import io.github.sefiraat.networks.slimefun.network.NetworkQuantumStorage;
@@ -61,14 +62,14 @@ public class NetworksMain implements CommandExecutor {
     public void fillQuantum(Player player, int amount) {
         final ItemStack itemStack = player.getInventory().getItemInMainHand();
         if (itemStack == null || itemStack.getType() == Material.AIR) {
-            player.sendMessage(Theme.ERROR + "你必须手持量子存储");
+            player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("hand_item_must_quantum_storage"));
             return;
         }
 
         SlimefunItem slimefunItem = SlimefunItem.getByItem(itemStack);
 
         if (!(slimefunItem instanceof NetworkQuantumStorage)) {
-            player.sendMessage(Theme.ERROR + "你手中的物品必须为量子存储");
+            player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("hand_item_must_quantum_storage"));
             return;
         }
 
@@ -80,7 +81,7 @@ public class NetworksMain implements CommandExecutor {
         );
 
         if (quantumCache == null || quantumCache.getItemStack() == null) {
-            player.sendMessage(Theme.ERROR + "量子存储未指定物品或已损坏");
+            player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("corrupted_quantum_storage"));
             return;
         }
 
@@ -88,6 +89,6 @@ public class NetworksMain implements CommandExecutor {
         DataTypeMethods.setCustom(meta, Keys.QUANTUM_STORAGE_INSTANCE, PersistentQuantumStorageType.TYPE, quantumCache);
         quantumCache.updateMetaLore(meta);
         itemStack.setItemMeta(meta);
-        player.sendMessage(Theme.SUCCESS + "已更新物品");
+        player.sendMessage(Theme.SUCCESS + Networks.getLocalization().getMessage("item_updated"));
     }
 }

--- a/src/main/java/io/github/sefiraat/networks/integrations/HudCallbacks.java
+++ b/src/main/java/io/github/sefiraat/networks/integrations/HudCallbacks.java
@@ -4,6 +4,7 @@ import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import io.github.schntgaispock.slimehud.SlimeHUD;
 import io.github.schntgaispock.slimehud.util.HudBuilder;
 import io.github.schntgaispock.slimehud.waila.HudController;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.stackcaches.QuantumCache;
 import io.github.sefiraat.networks.slimefun.network.NetworkGreedyBlock;
 import io.github.sefiraat.networks.slimefun.network.NetworkQuantumStorage;
@@ -15,7 +16,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 public class HudCallbacks {
 
-    private static final String EMPTY = "&7| 空";
+    private static final String EMPTY = "&7| " + Networks.getLocalization().getMessage("empty");
 
     public static void setup() {
         HudController controller = SlimeHUD.getHudController();

--- a/src/main/java/io/github/sefiraat/networks/integrations/NetheoPlants.java
+++ b/src/main/java/io/github/sefiraat/networks/integrations/NetheoPlants.java
@@ -23,45 +23,45 @@ public class NetheoPlants {
         "NTW_STONE_CHUNK_SEED",
         Skulls.SEED_PURPLE.getPlayerHead(),
         Theme.SEED,
-        "石块之种",
-        new String[]{"这种植物成熟后,", "收获时将获得石块."},
-        Stacks.getCanBePlacedOnLore("下界草方块", "(或净化等级更高的)")
+        Networks.getLocalization().getItemName("ntw_stone_chunk_seed"),
+        Networks.getLocalization().getItemLore("ntw_stone_chunk_seed"),
+        Stacks.getCanBePlacedOnLore(Networks.getLocalization().getItemItemAditionalLore("ntw_stone_chunk_seed"))
     );
 
     public static final SlimefunItemStack SYNTHETIC_SEED = Theme.themedSeed(
         "NTW_SYNTHETIC_SEED",
         Skulls.SEED_ORANGE.getPlayerHead(),
         Theme.SEED,
-        "人造之种",
-        new String[]{"这个种子没有任何效果."},
-        Stacks.getCanBePlacedOnLore("下界草方块", "(或净化等级更高的)")
+        Networks.getLocalization().getItemName("ntw_synthetic_seed"),
+        Networks.getLocalization().getItemLore("ntw_synthetic_seed"),
+        Stacks.getCanBePlacedOnLore(Networks.getLocalization().getItemItemAditionalLore("ntw_synthetic_seed"))
     );
 
     public static final SlimefunItemStack SYNTHETIC_EMERALD_SEED = Theme.themedSeed(
         "NTW_SYNTHETIC_EMERALD_SEED",
         Skulls.SEED_GREEN.getPlayerHead(),
         Theme.SEED,
-        "人造绿宝石之种",
-        new String[]{"这种植物成熟后,", "收获时将获得人造绿宝石."},
-        Stacks.getCanBePlacedOnLore("贪婪泥土", "(或净化等级更高的)")
+        Networks.getLocalization().getItemName("ntw_synthetic_emerald_seed"),
+        Networks.getLocalization().getItemLore("ntw_synthetic_emerald_seed"),
+        Stacks.getCanBePlacedOnLore(Networks.getLocalization().getItemItemAditionalLore("ntw_synthetic_emerald_seed"))
     );
 
     public static final SlimefunItemStack SYNTHETIC_DIAMOND_SEED = Theme.themedSeed(
         "NTW_SYNTHETIC_DIAMOND_SEED",
         Skulls.SEED_GREEN.getPlayerHead(),
         Theme.SEED,
-        "人造钻石之种",
-        new String[]{"这种植物成熟后,", "收获时将获得人造钻石."},
-        Stacks.getCanBePlacedOnLore("贪婪泥土", "(或净化等级更高的)")
+        Networks.getLocalization().getItemName("ntw_synthetic_diamond_seed"),
+        Networks.getLocalization().getItemLore("ntw_synthetic_diamond_seed"),
+        Stacks.getCanBePlacedOnLore(Networks.getLocalization().getItemItemAditionalLore("ntw_synthetic_diamond_seed"))
     );
 
     public static final SlimefunItemStack FRAGMENTED_SEED = Theme.themedSeed(
         "NTW_FRAGMENTED_SEED",
         Skulls.SEED_GREEN.getPlayerHead(),
         Theme.SEED,
-        "碎片之种",
-        new String[]{"这种植物成熟后,", "收获时将获得人造绿宝石碎片."},
-        Stacks.getCanBePlacedOnLore("贪婪泥土", "(或净化等级更高的)")
+        Networks.getLocalization().getItemName("ntw_fragmented_seed"),
+        Networks.getLocalization().getItemLore("ntw_fragmented_seed"),
+        Stacks.getCanBePlacedOnLore(Networks.getLocalization().getItemItemAditionalLore("ntw_fragmented_seed"))
     );
 
     public static void setup() {

--- a/src/main/java/io/github/sefiraat/networks/managers/SupportedPluginManager.java
+++ b/src/main/java/io/github/sefiraat/networks/managers/SupportedPluginManager.java
@@ -19,7 +19,7 @@ public class SupportedPluginManager {
     // endregion
 
     public SupportedPluginManager() {
-        Preconditions.checkArgument(instance == null, "Cannot instantiate class");
+        Preconditions.checkArgument(instance == null, Networks.getLocalization().getMessage("cannot_instantiate_class"));
         instance = this;
         this.infinityExpansion = Bukkit.getPluginManager().isPluginEnabled("InfinityExpansion");
         this.netheopoiesis = Bukkit.getPluginManager().isPluginEnabled("Netheopoiesis");

--- a/src/main/java/io/github/sefiraat/networks/network/stackcaches/CardInstance.java
+++ b/src/main/java/io/github/sefiraat/networks/network/stackcaches/CardInstance.java
@@ -1,5 +1,6 @@
 package io.github.sefiraat.networks.network.stackcaches;
 
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.utils.Theme;
 import net.guizhanss.guizhanlib.minecraft.helper.MaterialHelper;
 import org.bukkit.ChatColor;
@@ -73,7 +74,7 @@ public class CardInstance extends ItemStackCache {
 
     public String getLoreLine() {
         if (this.getItemStack() == null) {
-            return Theme.WARNING + "空";
+            return Theme.WARNING + Networks.getLocalization().getMessage("empty");
         }
         ItemMeta itemMeta = this.getItemMeta();
         String name;
@@ -82,7 +83,7 @@ public class CardInstance extends ItemStackCache {
         } else if (this.getItemType() != null) {
             name = MaterialHelper.getName(this.getItemType());
         } else {
-            name = "未知/错误";
+            name = Networks.getLocalization().getMessage("unknown_error");
         }
         return Theme.CLICK_INFO + name + ": " + Theme.PASSIVE + this.amount;
     }

--- a/src/main/java/io/github/sefiraat/networks/network/stackcaches/QuantumCache.java
+++ b/src/main/java/io/github/sefiraat/networks/network/stackcaches/QuantumCache.java
@@ -1,5 +1,6 @@
 package io.github.sefiraat.networks.network.stackcaches;
 
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.utils.Theme;
 import net.guizhanss.guizhanlib.minecraft.helper.inventory.ItemStackHelper;
 import org.bukkit.inventory.ItemStack;
@@ -88,25 +89,25 @@ public class QuantumCache extends ItemStackCache {
 
     public void addMetaLore(ItemMeta itemMeta) {
         final List<String> lore = itemMeta.hasLore() ? itemMeta.getLore() : new ArrayList<>();
-        String itemName = "无";
+        String itemName = Networks.getLocalization().getMessage("none");
         if (getItemStack() != null) {
             itemName = ItemStackHelper.getDisplayName(this.getItemStack());
         }
 
         lore.add("");
-        lore.add(Theme.CLICK_INFO + "物品: " + itemName);
-        lore.add(Theme.CLICK_INFO + "数量: " + this.getAmount());
+        lore.add(Theme.CLICK_INFO + Networks.getLocalization().getMessage("holding") + ": " + itemName);
+        lore.add(Theme.CLICK_INFO + Networks.getLocalization().getMessage("amount") + ": " + this.getAmount());
         itemMeta.setLore(lore);
     }
 
     public void updateMetaLore(ItemMeta itemMeta) {
         final List<String> lore = itemMeta.hasLore() ? itemMeta.getLore() : new ArrayList<>();
-        String itemName = "无";
+        String itemName = Networks.getLocalization().getMessage("none");
         if (getItemStack() != null) {
             itemName = ItemStackHelper.getDisplayName(this.getItemStack());
         }
-        lore.add(Theme.CLICK_INFO + "物品: " + itemName);
-        lore.add(Theme.CLICK_INFO + "数量: " + this.getAmount());
+        lore.add(Theme.CLICK_INFO + Networks.getLocalization().getMessage("holding") + ": " + itemName);
+        lore.add(Theme.CLICK_INFO + Networks.getLocalization().getMessage("amount") + ": " + this.getAmount());
         itemMeta.setLore(lore);
     }
 }

--- a/src/main/java/io/github/sefiraat/networks/slimefun/NetworksItemGroups.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/NetworksItemGroups.java
@@ -22,7 +22,7 @@ public final class NetworksItemGroups {
         Keys.newKey("main"),
         new CustomItemStack(
             new ItemStack(Material.BLACK_STAINED_GLASS),
-            Theme.MAIN.getColor() + "网络 (Networks)"
+            Theme.MAIN.getColor() + Networks.getLocalization().getMessage("networks")
         )
     );
 
@@ -30,7 +30,7 @@ public final class NetworksItemGroups {
         Keys.newKey("materials"),
         new CustomItemStack(
             new ItemStack(Material.WHITE_STAINED_GLASS),
-            Theme.MAIN.getColor() + "合成材料"
+            Theme.MAIN.getColor() + Networks.getLocalization().getMessage("crafting_materials")
         )
     );
 
@@ -38,7 +38,7 @@ public final class NetworksItemGroups {
         Keys.newKey("tools"),
         new CustomItemStack(
             new ItemStack(Material.PAINTING),
-            Theme.MAIN.getColor() + "网络管理工具"
+            Theme.MAIN.getColor() + Networks.getLocalization().getMessage("network_management_tools")
         )
     );
 
@@ -46,7 +46,7 @@ public final class NetworksItemGroups {
         Keys.newKey("network_items"),
         new CustomItemStack(
             new ItemStack(Material.BLACK_STAINED_GLASS),
-            Theme.MAIN.getColor() + "网络物品"
+            Theme.MAIN.getColor() + Networks.getLocalization().getMessage("network_items")
         )
     );
 
@@ -54,7 +54,7 @@ public final class NetworksItemGroups {
         Keys.newKey("network_quantums"),
         new CustomItemStack(
             new ItemStack(Material.WHITE_TERRACOTTA),
-            Theme.MAIN.getColor() + "量子存储设备"
+            Theme.MAIN.getColor() + Networks.getLocalization().getMessage("network_quantum_storage_devices")
         )
     );
 
@@ -62,7 +62,7 @@ public final class NetworksItemGroups {
         Keys.newKey("disabled_items"),
         new CustomItemStack(
             new ItemStack(Material.BARRIER),
-            Theme.MAIN.getColor() + "已禁用/移除的物品"
+            Theme.MAIN.getColor() + Networks.getLocalization().getMessage("disabled_items")
         )
     );
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/NetworksSlimefunItemStacks.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/NetworksSlimefunItemStacks.java
@@ -1,5 +1,6 @@
 package io.github.sefiraat.networks.slimefun;
 
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.slimefun.network.NetworkQuantumStorage;
 import io.github.sefiraat.networks.slimefun.tools.NetworkRemote;
 import io.github.sefiraat.networks.utils.Theme;
@@ -17,6 +18,8 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import javax.annotation.Nonnull;
 import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.stream.Stream;
 
 /**
  * Creating SlimefunItemstacks here due to some items being created in Enums so this will
@@ -100,665 +103,604 @@ public class NetworksSlimefunItemStacks {
             "NTW_SYNTHETIC_EMERALD_SHARD",
             new ItemStack(Material.LIME_DYE),
             Theme.CRAFTING,
-            "人造绿宝石碎片",
-            "一块人造绿宝石的碎片",
-            "是信息传输的支柱"
+            Networks.getLocalization().getItemName("ntw_synthetic_emerald_shard"),
+            Networks.getLocalization().getItemLore("ntw_synthetic_emerald_shard")
         );
 
         OPTIC_GLASS = Theme.themedSlimefunItemStack(
             "NTW_OPTIC_GLASS",
             new ItemStack(Material.GLASS),
             Theme.CRAFTING,
-            "光学玻璃",
-            "能够传输少量信息的玻璃"
+            Networks.getLocalization().getItemName("ntw_optic_glass"),
+            Networks.getLocalization().getItemLore("ntw_optic_glass")
         );
 
         OPTIC_CABLE = Theme.themedSlimefunItemStack(
             "NTW_OPTIC_CABLE",
             new ItemStack(Material.STRING),
             Theme.CRAFTING,
-            "光缆",
-            "能够传输大量信息的光缆"
+            Networks.getLocalization().getItemName("ntw_optic_cable"),
+            Networks.getLocalization().getItemLore("ntw_optic_cable")
         );
 
         OPTIC_STAR = Theme.themedSlimefunItemStack(
             "NTW_OPTIC_STAR",
             new ItemStack(Material.NETHER_STAR),
             Theme.CRAFTING,
-            "光学之星",
-            "能够传输大量信息的星"
+            Networks.getLocalization().getItemName("ntw_optic_star"),
+            Networks.getLocalization().getItemLore("ntw_optic_star")
         );
 
         RADIOACTIVE_OPTIC_STAR = Theme.themedSlimefunItemStack(
             "NTW_RADIOACTIVE_OPTIC_STAR",
             getPreEnchantedItemStack(Material.NETHER_STAR, true, new Pair<>(VersionedEnchantment.LUCK_OF_THE_SEA, 1)),
             Theme.CRAFTING,
-            "放射性光学之星",
-            "能够传输几乎无限信息的星"
+            Networks.getLocalization().getItemName("ntw_radioactive_optic_star"),
+            Networks.getLocalization().getItemLore("ntw_radioactive_optic_star")
         );
 
         SHRINKING_BASE = Theme.themedSlimefunItemStack(
             "NTW_SHRINKING_BASE",
             getPreEnchantedItemStack(Material.PISTON, true, new Pair<>(VersionedEnchantment.LUCK_OF_THE_SEA, 1)),
             Theme.CRAFTING,
-            "缩小底座",
-            "可以让大型物体变小的装置"
+            Networks.getLocalization().getItemName("ntw_shrinking_base"),
+            Networks.getLocalization().getItemLore("ntw_shrinking_base")
         );
 
         SIMPLE_NANOBOTS = Theme.themedSlimefunItemStack(
             "NTW_SIMPLE_NANOBOTS",
             new ItemStack(Material.MELON_SEEDS),
             Theme.CRAFTING,
-            "简易纳米机器人",
-            "可以帮助你完成精密任务的微型机器人"
+            Networks.getLocalization().getItemName("ntw_simple_nanobots"),
+            Networks.getLocalization().getItemLore("ntw_simple_nanobots")
         );
 
         ADVANCED_NANOBOTS = Theme.themedSlimefunItemStack(
             "NTW_ADVANCED_NANOBOTS",
             getPreEnchantedItemStack(Material.MELON_SEEDS, true, new Pair<>(VersionedEnchantment.LUCK_OF_THE_SEA, 1)),
             Theme.CRAFTING,
-            "高级纳米机器人",
-            "可以帮助你完成精密任务的微型机器人",
-            "比简易版更智能，更高效"
+            Networks.getLocalization().getItemName("ntw_advanced_nanobots"),
+            Networks.getLocalization().getItemLore("ntw_advanced_nanobots")
         );
 
         AI_CORE = Theme.themedSlimefunItemStack(
             "NTW_AI_CORE",
             new ItemStack(Material.BRAIN_CORAL_BLOCK),
             Theme.CRAFTING,
-            "人工智能核心",
-            "在脆弱外壳中的初代人工智能"
+            Networks.getLocalization().getItemName("ntw_ai_core"),
+            Networks.getLocalization().getItemLore("ntw_ai_core")
         );
 
         EMPOWERED_AI_CORE = Theme.themedSlimefunItemStack(
             "NTW_EMPOWERED_AI_CORE",
             new ItemStack(Material.TUBE_CORAL_BLOCK),
             Theme.CRAFTING,
-            "充能人工智能核心",
-            "在外壳中的高级人工智能"
+            Networks.getLocalization().getItemName("ntw_empowered_ai_core"),
+            Networks.getLocalization().getItemLore("ntw_empowered_ai_core")
         );
 
         PRISTINE_AI_CORE = Theme.themedSlimefunItemStack(
             "NTW_PRISTINE_AI_CORE",
             getPreEnchantedItemStack(Material.TUBE_CORAL_BLOCK, true, new Pair<>(VersionedEnchantment.LUCK_OF_THE_SEA, 1)),
             Theme.CRAFTING,
-            "古代人工智能核心",
-            "据说是从上古遗迹中挖掘出来的",
-            "完美级人工智能"
+            Networks.getLocalization().getItemName("ntw_pristine_ai_core"),
+            Networks.getLocalization().getItemLore("ntw_pristine_ai_core")
         );
 
         INTERDIMENSIONAL_PRESENCE = Theme.themedSlimefunItemStack(
             "NTW_INTERDIMENSIONAL_PRESENCE",
             getPreEnchantedItemStack(Material.ARMOR_STAND, true, new Pair<>(VersionedEnchantment.LUCK_OF_THE_SEA, 1)),
             Theme.CRAFTING,
-            "跨跃维度的存在",
-            "这种完美级的人工智能",
-            "甚至还掌握了跨越维度的能力"
+            Networks.getLocalization().getItemName("ntw_interdimensional_presence"),
+            Networks.getLocalization().getItemLore("ntw_interdimensional_presence")
         );
 
         NETWORK_CONTROLLER = Theme.themedSlimefunItemStack(
             "NTW_CONTROLLER",
             new ItemStack(Material.BLACK_STAINED_GLASS),
             Theme.MACHINE,
-            "网络控制器",
-            "网络控制器是网络的核心部分",
-            "每个网络最多有1个控制器"
+            Networks.getLocalization().getItemName("ntw_controller"),
+            Networks.getLocalization().getItemLore("ntw_controller")
         );
 
         NETWORK_BRIDGE = Theme.themedSlimefunItemStack(
             "NTW_BRIDGE",
             new ItemStack(Material.WHITE_STAINED_GLASS),
             Theme.MACHINE,
-            "网桥",
-            "网桥用于连接不同的网络物品",
-            "来形成一个完整的网络"
+            Networks.getLocalization().getItemName("ntw_bridge"),
+            Networks.getLocalization().getItemLore("ntw_bridge")
         );
 
         NETWORK_MONITOR = Theme.themedSlimefunItemStack(
             "NTW_MONITOR",
             new ItemStack(Material.GREEN_STAINED_GLASS),
             Theme.MACHINE,
-            "网络监视器",
-            "网络监视器可以与附近的方块交互",
-            "让指定方块可以接入网络",
-            "",
-            "目前支持:",
-            "无尽科技 - 存储单元",
-            "网络 - 量子存储"
+            Networks.getLocalization().getItemName("ntw_monitor"),
+            Networks.getLocalization().getItemLore("ntw_monitor")
         );
 
         NETWORK_IMPORT = Theme.themedSlimefunItemStack(
             "NTW_IMPORT",
             new ItemStack(Material.RED_STAINED_GLASS),
             Theme.MACHINE,
-            "网络入口",
-            "网络入口会将其中的物品送入网络中",
-            "每个SF tick可传输最多9组物品",
-            "可接收来自货运网络的物品"
+            Networks.getLocalization().getItemName("ntw_import"),
+            Networks.getLocalization().getItemLore("ntw_import")
         );
 
         NETWORK_EXPORT = Theme.themedSlimefunItemStack(
             "NTW_EXPORT",
             new ItemStack(Material.BLUE_STAINED_GLASS),
             Theme.MACHINE,
-            "网络出口",
-            "网络出口可以设置成",
-            "持续将1组指定的物品送出网络",
-            "可以使用货运网络从中提取物品"
+            Networks.getLocalization().getItemName("ntw_export"),
+            Networks.getLocalization().getItemLore("ntw_export")
         );
 
         NETWORK_GRABBER = Theme.themedSlimefunItemStack(
             "NTW_GRABBER",
             new ItemStack(Material.MAGENTA_STAINED_GLASS),
             Theme.MACHINE,
-            "网络抓取器",
-            "网络抓取器会尝试从",
-            "指定的机器中抓取第一个物品"
+            Networks.getLocalization().getItemName("ntw_grabber"),
+            Networks.getLocalization().getItemLore("ntw_grabber")
         );
 
         NETWORK_PUSHER = Theme.themedSlimefunItemStack(
             "NTW_PUSHER",
             new ItemStack(Material.BROWN_STAINED_GLASS),
             Theme.MACHINE,
-            "网络推送器",
-            "网络推送器会尝试将",
-            "指定的物品送入机器中"
+            Networks.getLocalization().getItemName("ntw_pusher"),
+            Networks.getLocalization().getItemLore("ntw_pusher")
         );
 
         NETWORK_CONTROL_X = Theme.themedSlimefunItemStack(
             "NTW_CONTROL_X",
             new ItemStack(Material.WHITE_GLAZED_TERRACOTTA),
             Theme.MACHINE,
-            "网络剪切器",
-            "网络剪切器会尝试将",
-            "方块从世界中\"剪切\"到网络中",
-            "仅支持原版非容器方块.",
-            "",
-            MessageFormat.format("{0}网络电力消耗: {1}每次操作 {2}J", Theme.CLICK_INFO, Theme.PASSIVE, 100)
+            Networks.getLocalization().getItemName("ntw_control_x"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_control_x")),
+                Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_control_x")[0], Theme.CLICK_INFO, Theme.PASSIVE, 100))
+            ).toArray(String[]::new)
+            
         );
 
         NETWORK_CONTROL_V = Theme.themedSlimefunItemStack(
             "NTW_CONTROL_V",
             new ItemStack(Material.PURPLE_GLAZED_TERRACOTTA),
             Theme.MACHINE,
-            "网络粘贴器",
-            "网络粘贴器会尝试将",
-            "方块从网络中\"粘贴\"到世界中",
-            "仅支持原版方块.",
-            "",
-            MessageFormat.format("{0}网络电力消耗: {1}每次操作 {2}J", Theme.CLICK_INFO, Theme.PASSIVE, 100)
+            Networks.getLocalization().getItemName("ntw_control_v"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_control_v")),
+                Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_control_v")[0], Theme.CLICK_INFO, Theme.PASSIVE, 100))
+            ).toArray(String[]::new)
         );
 
         NETWORK_VACUUM = Theme.themedSlimefunItemStack(
             "NTW_VACUUM",
             new ItemStack(Material.ORANGE_GLAZED_TERRACOTTA),
             Theme.MACHINE,
-            "网络吸尘器",
-            "网络吸尘器可以将周围",
-            "4x4范围内的掉落物品吸收,",
-            "然后尝试将这些物品送入网络中.",
-            "",
-            MessageFormat.format("{0}网络电力消耗: {1}{2}J/粘液刻", Theme.CLICK_INFO, Theme.PASSIVE, 100)
+            Networks.getLocalization().getItemName("ntw_vacuum"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_vacuum")),
+                Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_vacuum")[0], Theme.CLICK_INFO, Theme.PASSIVE, 100))
+            ).toArray(String[]::new)
         );
 
         NETWORK_VANILLA_GRABBER = Theme.themedSlimefunItemStack(
             "NTW_VANILLA_GRABBER",
             new ItemStack(Material.ORANGE_STAINED_GLASS),
             Theme.MACHINE,
-            "网络原版容器抓取器",
-            "网络原版容器抓取器会尝试",
-            "抓取指定原版容器中的第一个物品.",
-            "",
-            "该机器不能与网络直接交互,",
-            "你还需要一个网络抓取器",
-            "将本机器中的物品输入到网络中."
+            Networks.getLocalization().getItemName("ntw_vanilla_grabber"),
+            Networks.getLocalization().getItemLore("ntw_vanilla_grabber")
         );
 
         NETWORK_VANILLA_PUSHER = Theme.themedSlimefunItemStack(
             "NTW_VANILLA_PUSHER",
             new ItemStack(Material.LIME_STAINED_GLASS),
             Theme.MACHINE,
-            "网络原版容器推送器",
-            "网络原版容器推送器会尝试",
-            "推送其中的物品到指定原版容器中.",
-            "",
-            "该机器不能与网络直接交互,",
-            "你还需要一个网络推送器",
-            "将网络中的物品推送到本机器中."
+            Networks.getLocalization().getItemName("ntw_vanilla_pusher"),
+            Networks.getLocalization().getItemLore("ntw_vanilla_pusher")
         );
 
         NETWORK_WIRELESS_TRANSMITTER = Theme.themedSlimefunItemStack(
             "NTW_NETWORK_WIRELESS_TRANSMITTER",
             new ItemStack(Material.CYAN_STAINED_GLASS),
             Theme.MACHINE,
-            "网络无线发射器",
-            "网络无线发射器可以",
-            "将其中的物品传输到绑定的",
-            "网络无线接收器中(只能在同一世界).",
-            "使用网络无线配置器来进行绑定.",
-            "每次传输会消耗 500 J 网络电力."
+            Networks.getLocalization().getItemName("ntw_network_wireless_transmitter"),
+            Networks.getLocalization().getItemLore("ntw_network_wireless_transmitter")
         );
 
         NETWORK_WIRELESS_RECEIVER = Theme.themedSlimefunItemStack(
             "NTW_NETWORK_WIRELESS_RECEIVER",
             new ItemStack(Material.PURPLE_STAINED_GLASS),
             Theme.MACHINE,
-            "网络无线接收器",
-            "网络无线接收器可以",
-            "接收来自绑定的网络无线发射器",
-            "中的物品(只能在同一世界).",
-            "每粘液刻会把接收到的物品",
-            "尝试推送到网络中."
+            Networks.getLocalization().getItemName("ntw_network_wireless_receiver"),
+            Networks.getLocalization().getItemLore("ntw_network_wireless_receiver")
         );
 
         NETWORK_PURGER = Theme.themedSlimefunItemStack(
             "NTW_TRASH",
             new ItemStack(Material.OBSERVER),
             Theme.MACHINE,
-            "网络清除器",
-            "网络清除器会从网络中",
-            "不断地移除指定物品",
-            "清除的物品会立即消失，谨慎使用!"
+            Networks.getLocalization().getItemName("ntw_trash"),
+            Networks.getLocalization().getItemLore("ntw_trash")
         );
 
         NETWORK_GRID = Theme.themedSlimefunItemStack(
             "NTW_GRID",
             new ItemStack(Material.NOTE_BLOCK),
             Theme.MACHINE,
-            "网格",
-            "网格允许你查看网络中所有的物品",
-            "你也可以直接放入或取出物品"
+            Networks.getLocalization().getItemName("ntw_grid"),
+            Networks.getLocalization().getItemLore("ntw_grid")
         );
 
         NETWORK_CRAFTING_GRID = Theme.themedSlimefunItemStack(
             "NTW_CRAFTING_GRID",
             new ItemStack(Material.REDSTONE_LAMP),
             Theme.MACHINE,
-            "网格(带合成)",
-            "这种网格与普通网格类似",
-            "但会显示更少的物品",
-            "不过你可以直接使用网络中的物品",
-            "进行合成"
+            Networks.getLocalization().getItemName("ntw_crafting_grid"),
+            Networks.getLocalization().getItemLore("ntw_crafting_grid")
         );
 
         NETWORK_CELL = Theme.themedSlimefunItemStack(
             "NTW_CELL",
             new ItemStack(Material.HONEYCOMB_BLOCK),
             Theme.MACHINE,
-            "网络单元",
-            "网络单元拥有54格空间(相当于一个大箱子)",
-            "可以通过网络访问其中的物品",
-            "也可以直接打开"
+            Networks.getLocalization().getItemName("ntw_cell"),
+            Networks.getLocalization().getItemLore("ntw_cell")
         );
 
         NETWORK_GREEDY_BLOCK = Theme.themedSlimefunItemStack(
             "NTW_GREEDY_BLOCK",
             new ItemStack(Material.SHROOMLIGHT),
             Theme.MACHINE,
-            "网络阻断器",
-            "网络阻断器可以设置一个物品,",
-            "然后会从网络各处输入中",
-            "收集指定的物品,最多为1组.",
-            "收集满后,会阻断该物品在网络中的传输,",
-            "任何其他网络方块都不会收到该物品."
+            Networks.getLocalization().getItemName("ntw_greedy_block"),
+            Networks.getLocalization().getItemLore("ntw_greedy_block")
         );
 
         NETWORK_QUANTUM_WORKBENCH = Theme.themedSlimefunItemStack(
             "NTW_QUANTUM_WORKBENCH",
             new ItemStack(Material.DRIED_KELP_BLOCK),
             Theme.MACHINE,
-            "网络量子工作台",
-            "可以合成量子存储"
+            Networks.getLocalization().getItemName("ntw_quantum_workbench"),
+            Networks.getLocalization().getItemLore("ntw_quantum_workbench")
         );
 
         NETWORK_QUANTUM_STORAGE_1 = Theme.themedSlimefunItemStack(
             "NTW_QUANTUM_STORAGE_1",
             new ItemStack(Material.WHITE_TERRACOTTA),
             Theme.MACHINE,
-            "网络量子存储 (4K)",
-            "可存储 " + NetworkQuantumStorage.getSizes()[0] + " 个物品",
-            "",
-            "在量子奇点中存储大量物品"
+            Networks.getLocalization().getItemName("ntw_quantum_storage_1"),
+            Networks.getLocalization().getItemLore("ntw_quantum_storage_1")
         );
 
         NETWORK_QUANTUM_STORAGE_2 = Theme.themedSlimefunItemStack(
             "NTW_QUANTUM_STORAGE_2",
             new ItemStack(Material.LIGHT_GRAY_TERRACOTTA),
             Theme.MACHINE,
-            "网络量子存储 (32K)",
-            "可存储 " + NetworkQuantumStorage.getSizes()[1] + " 个物品",
-            "",
-            "在量子奇点中存储大量物品"
+            Networks.getLocalization().getItemName("ntw_quantum_storage_2"),
+            Networks.getLocalization().getItemLore("ntw_quantum_storage_2")
         );
 
         NETWORK_QUANTUM_STORAGE_3 = Theme.themedSlimefunItemStack(
             "NTW_QUANTUM_STORAGE_3",
             new ItemStack(Material.GRAY_TERRACOTTA),
             Theme.MACHINE,
-            "网络量子存储 (262K)",
-            "可存储 " + NetworkQuantumStorage.getSizes()[2] + " 个物品",
-            "",
-            "在量子奇点中存储大量物品"
+            Networks.getLocalization().getItemName("ntw_quantum_storage_3"),
+            Networks.getLocalization().getItemLore("ntw_quantum_storage_3")
         );
 
         NETWORK_QUANTUM_STORAGE_4 = Theme.themedSlimefunItemStack(
             "NTW_QUANTUM_STORAGE_4",
             new ItemStack(Material.BROWN_TERRACOTTA),
             Theme.MACHINE,
-            "网络量子存储 (2M)",
-            "可存储 " + NetworkQuantumStorage.getSizes()[3] + " 个物品",
-            "",
-            "在量子奇点中存储大量物品"
+            Networks.getLocalization().getItemName("ntw_quantum_storage_4"),
+            Networks.getLocalization().getItemLore("ntw_quantum_storage_4")
         );
 
         NETWORK_QUANTUM_STORAGE_5 = Theme.themedSlimefunItemStack(
             "NTW_QUANTUM_STORAGE_5",
             new ItemStack(Material.BLACK_TERRACOTTA),
             Theme.MACHINE,
-            "网络量子存储 (16M)",
-            "可存储 " + NetworkQuantumStorage.getSizes()[4] + " 个物品",
-            "",
-            "在量子奇点中存储大量物品"
+            Networks.getLocalization().getItemName("ntw_quantum_storage_5"),
+            Networks.getLocalization().getItemLore("ntw_quantum_storage_5")
         );
 
         NETWORK_QUANTUM_STORAGE_6 = Theme.themedSlimefunItemStack(
             "NTW_QUANTUM_STORAGE_6",
             new ItemStack(Material.PURPLE_TERRACOTTA),
             Theme.MACHINE,
-            "网络量子存储 (134M)",
-            "可存储 " + NetworkQuantumStorage.getSizes()[5] + " 个物品",
-            "",
-            "在量子奇点中存储大量物品"
+            Networks.getLocalization().getItemName("ntw_quantum_storage_6"),
+            Networks.getLocalization().getItemLore("ntw_quantum_storage_6")
         );
 
         NETWORK_QUANTUM_STORAGE_7 = Theme.themedSlimefunItemStack(
             "NTW_QUANTUM_STORAGE_7",
             new ItemStack(Material.MAGENTA_TERRACOTTA),
             Theme.MACHINE,
-            "网络量子存储 (1B)",
-            "可存储 " + NetworkQuantumStorage.getSizes()[6] + " 个物品",
-            "",
-            "在量子奇点中存储大量物品"
+            Networks.getLocalization().getItemName("ntw_quantum_storage_7"),
+            Networks.getLocalization().getItemLore("ntw_quantum_storage_7")
         );
 
         NETWORK_QUANTUM_STORAGE_8 = Theme.themedSlimefunItemStack(
             "NTW_QUANTUM_STORAGE_8",
             new ItemStack(Material.RED_TERRACOTTA),
             Theme.MACHINE,
-            "网络量子存储 (∞)",
-            "可存储几乎无限多个物品",
-            "",
-            "在量子奇点中存储大量物品"
+            Networks.getLocalization().getItemName("ntw_quantum_storage_8"),
+            Networks.getLocalization().getItemLore("ntw_quantum_storage_8")
         );
 
         NETWORK_CAPACITOR_1 = Theme.themedSlimefunItemStack(
             "NTW_CAPACITOR_1",
             new ItemStack(Material.BROWN_GLAZED_TERRACOTTA),
             Theme.MACHINE,
-            "网络电容 (1)",
-            "网络电容可以接收来自",
-            "能源网络的电力并存储起来",
-            "以供其他网络设备使用",
-            "",
-            MessageFormat.format("{0}容量: {1}{2}", Theme.CLICK_INFO, Theme.PASSIVE, 1000)
+            Networks.getLocalization().getItemName("ntw_capacitor_1"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_capacitor_1")),
+                Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_capacitor_1")[0], Theme.CLICK_INFO, Theme.PASSIVE, 1000))
+            ).toArray(String[]::new)
         );
 
         NETWORK_CAPACITOR_2 = Theme.themedSlimefunItemStack(
             "NTW_CAPACITOR_2",
             new ItemStack(Material.GREEN_GLAZED_TERRACOTTA),
             Theme.MACHINE,
-            "网络电容 (2)",
-            "网络电容可以接收来自",
-            "能源网络的电力并存储起来",
-            "以供其他网络设备使用",
-            "",
-            MessageFormat.format("{0}容量: {1}{2}", Theme.CLICK_INFO, Theme.PASSIVE, 10000)
+            Networks.getLocalization().getItemName("ntw_capacitor_2"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_capacitor_2")),
+                Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_capacitor_2")[0], Theme.CLICK_INFO, Theme.PASSIVE, 10000))
+            ).toArray(String[]::new)
         );
 
         NETWORK_CAPACITOR_3 = Theme.themedSlimefunItemStack(
             "NTW_CAPACITOR_3",
             new ItemStack(Material.BLACK_GLAZED_TERRACOTTA),
             Theme.MACHINE,
-            "网络电容 (3)",
-            "网络电容可以接收来自",
-            "能源网络的电力并存储起来",
-            "以供其他网络设备使用",
-            "",
-            MessageFormat.format("{0}容量: {1}{2}", Theme.CLICK_INFO, Theme.PASSIVE, 100000)
+            Networks.getLocalization().getItemName("ntw_capacitor_3"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_capacitor_3")),
+                Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_capacitor_3")[0], Theme.CLICK_INFO, Theme.PASSIVE, 100000))
+            ).toArray(String[]::new)
         );
 
         NETWORK_CAPACITOR_4 = Theme.themedSlimefunItemStack(
             "NTW_CAPACITOR_4",
             new ItemStack(Material.GRAY_GLAZED_TERRACOTTA),
             Theme.MACHINE,
-            "网络电容 (4)",
-            "网络电容可以接收来自",
-            "能源网络的电力并存储起来",
-            "以供其他网络设备使用",
-            "",
-            MessageFormat.format("{0}容量: {1}{2}", Theme.CLICK_INFO, Theme.PASSIVE, 1000000)
+            Networks.getLocalization().getItemName("ntw_capacitor_4"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_capacitor_4")),
+                Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_capacitor_4")[0], Theme.CLICK_INFO, Theme.PASSIVE, 1000000))
+            ).toArray(String[]::new)
         );
 
         NETWORK_POWER_OUTLET_1 = Theme.themedSlimefunItemStack(
             "NTW_POWER_OUTLET_1",
             new ItemStack(Material.YELLOW_GLAZED_TERRACOTTA),
             Theme.MACHINE,
-            "网络插口 (1)",
-            "网络插口可以将网络中存储的电力",
-            "传输回电力网络中.",
-            "将网络插口理解为发电机.",
-            "",
-            "会有 20% 的损耗.",
-            "",
-            MessageFormat.format("{0}可存储: {1}{2}J", Theme.CLICK_INFO, Theme.PASSIVE, 500)
+            Networks.getLocalization().getItemName("ntw_power_outlet_1"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_power_outlet_1")),
+                Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_power_outlet_1")[0], Theme.CLICK_INFO, Theme.PASSIVE, 500))
+            ).toArray(String[]::new)
         );
 
         NETWORK_POWER_OUTLET_2 = Theme.themedSlimefunItemStack(
             "NTW_POWER_OUTLET_2",
             new ItemStack(Material.RED_GLAZED_TERRACOTTA),
             Theme.MACHINE,
-            "网络插口 (2)",
-            "网络插口可以将网络中存储的电力",
-            "传输回电力网络中.",
-            "将网络插口理解为发电机.",
-            "",
-            "会有 20% 的损耗.",
-            "",
-            MessageFormat.format("{0}可存储: {1}{2}J", Theme.CLICK_INFO, Theme.PASSIVE, 2000)
+            Networks.getLocalization().getItemName("ntw_power_outlet_2"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_power_outlet_2")),
+                Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_power_outlet_2")[0], Theme.CLICK_INFO, Theme.PASSIVE, 2000))
+            ).toArray(String[]::new)
         );
 
         NETWORK_POWER_DISPLAY = Theme.themedSlimefunItemStack(
             "NTW_POWER_DISPLAY",
             new ItemStack(Material.TINTED_GLASS),
             Theme.MACHINE,
-            "网络电表",
-            "网络电表会显示网络中的电力情况",
-            "很简单, 对吧?"
+            Networks.getLocalization().getItemName("ntw_power_display"),
+            Networks.getLocalization().getItemLore("ntw_power_display")
         );
 
         NETWORK_RECIPE_ENCODER = Theme.themedSlimefunItemStack(
             "NTW_RECIPE_ENCODER",
             new ItemStack(Material.TARGET),
             Theme.MACHINE,
-            "网络配方编码器",
-            "可以根据输入的物品来制作合成蓝图",
-            "",
-            MessageFormat.format("{0}网络电力消耗: {1}{2} 每次编码", Theme.CLICK_INFO, Theme.PASSIVE, 20000)
+            Networks.getLocalization().getItemName("ntw_recipe_encoder"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_recipe_encoder")),
+                Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_recipe_encoder")[0], Theme.CLICK_INFO, Theme.PASSIVE, 20000))
+            ).toArray(String[]::new)
         );
 
         NETWORK_AUTO_CRAFTER = Theme.themedSlimefunItemStack(
             "NTW_AUTO_CRAFTER",
             new ItemStack(Material.BLACK_GLAZED_TERRACOTTA),
             Theme.MACHINE,
-            "网络自动合成机",
-            "网络自动合成机需要合成蓝图才能工作。",
-            "当网络中没有蓝图的目标物品时，",
-            "机器会自动从网络中选取材料进行合成",
-            "(需要网络中有足够的原材料)",
-            "",
-            MessageFormat.format("{0}网络电力消耗: {1}{2} 每次合成", Theme.CLICK_INFO, Theme.PASSIVE, 64)
+            Networks.getLocalization().getItemName("ntw_auto_crafter"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_auto_crafter")),
+                Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_auto_crafter")[0], Theme.CLICK_INFO, Theme.PASSIVE, 64))
+            ).toArray(String[]::new)
         );
 
         NETWORK_AUTO_CRAFTER_WITHHOLDING = Theme.themedSlimefunItemStack(
             "NTW_AUTO_CRAFTER_WITHHOLDING",
             new ItemStack(Material.WHITE_GLAZED_TERRACOTTA),
             Theme.MACHINE,
-            "网络自动合成机 (预留版)",
-            "网络自动合成机需要合成蓝图才能工作。",
-            "当网络中没有蓝图的目标物品时，",
-            "机器会自动从网络中选取材料进行合成",
-            "(需要网络中有足够的原材料)",
-            "",
-            "预留版的自动合成机会不断进行合成",
-            "直到输出栏拥有1组物品",
-            "这一组物品可以在网络中访问",
-            "也可以通过货运系统取出",
-            "",
-            MessageFormat.format("{0}网络电力消耗: {1}{2} 每次合成", Theme.CLICK_INFO, Theme.PASSIVE, 128)
+            Networks.getLocalization().getItemName("ntw_auto_crafter_withholding"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_auto_crafter_withholding")),
+                Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_auto_crafter_withholding")[0], Theme.CLICK_INFO, Theme.PASSIVE, 128))
+            ).toArray(String[]::new)
         );
 
         CRAFTING_BLUEPRINT = Theme.themedSlimefunItemStack(
             "NTW_CRAFTING_BLUEPRINT",
             new ItemStack(Material.BLUE_DYE),
             Theme.TOOL,
-            "合成蓝图",
-            "一张空白的蓝图",
-            "可以存储一个合成配方"
+            Networks.getLocalization().getItemName("ntw_crafting_blueprint"),
+            Networks.getLocalization().getItemLore("ntw_crafting_blueprint")
         );
 
         NETWORK_PROBE = Theme.themedSlimefunItemStack(
             "NTW_PROBE",
             new ItemStack(Material.CLOCK),
             Theme.TOOL,
-            "网络探测器",
-            "右键点击网络控制器",
-            "可以查看网络中的节点数量"
+            Networks.getLocalization().getItemName("ntw_probe"),
+            Networks.getLocalization().getItemLore("ntw_probe")
         );
 
         NETWORK_REMOTE = Theme.themedSlimefunItemStack(
             "NTW_REMOTE",
             new ItemStack(Material.PAINTING),
             Theme.TOOL,
-            "网络远程访问器",
-            "远程打开绑定的网格",
-            "需要加载网格所在区块",
-            "",
-            MessageFormat.format("{0}Shift+右键点击 {1}普通网格以进行绑定", Theme.CLICK_INFO, Theme.PASSIVE),
-            "",
-            MessageFormat.format("{0}范围: {1}{2}格", Theme.CLICK_INFO, Theme.PASSIVE, NetworkRemote.getRanges()[0])
+            Networks.getLocalization().getItemName("ntw_remote"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_remote")),
+                Stream.concat(
+                    Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_remote")[0], Theme.CLICK_INFO, Theme.PASSIVE)),
+                    Stream.concat(
+                        Stream.of(""),
+                        Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_remote")[1], Theme.CLICK_INFO, Theme.PASSIVE, NetworkRemote.getRanges()[1]))
+                    )
+                )
+            ).toArray(String[]::new)
         );
 
         NETWORK_REMOTE_EMPOWERED = Theme.themedSlimefunItemStack(
             "NTW_REMOTE_EMPOWERED",
             new ItemStack(Material.ITEM_FRAME),
             Theme.TOOL,
-            "充能网络远程访问器",
-            "远程打开绑定的网格",
-            "需要加载网格所在区块",
-            "",
-            MessageFormat.format("{0}Shift+右键点击 {1}普通网格以进行绑定", Theme.CLICK_INFO, Theme.PASSIVE),
-            "",
-            MessageFormat.format("{0}范围: {1}{2}格", Theme.CLICK_INFO, Theme.PASSIVE, NetworkRemote.getRanges()[1])
+            Networks.getLocalization().getItemName("ntw_remote_empowered"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_remote_empowered")),
+                Stream.concat(
+                    Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_remote_empowered")[0], Theme.CLICK_INFO, Theme.PASSIVE)),
+                    Stream.concat(
+                        Stream.of(""),
+                        Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_remote_empowered")[1], Theme.CLICK_INFO, Theme.PASSIVE, NetworkRemote.getRanges()[1]))
+                    )
+                )
+            ).toArray(String[]::new)
         );
 
         NETWORK_REMOTE_PRISTINE = Theme.themedSlimefunItemStack(
             "NTW_REMOTE_PRISTINE",
             new ItemStack(Material.GLOW_ITEM_FRAME),
             Theme.TOOL,
-            "古代网络远程访问器",
-            "远程打开绑定的网格",
-            "需要加载网格所在区块",
-            "",
-            MessageFormat.format("{0}Shift+右键点击 {1}普通网格以进行绑定", Theme.CLICK_INFO, Theme.PASSIVE),
-            "",
-            MessageFormat.format("{0}范围: {1}{2}", Theme.CLICK_INFO, Theme.PASSIVE, "无限制(仅同一世界)")
+            Networks.getLocalization().getItemName("ntw_remote_pristine"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_remote_pristine")),
+                Stream.concat(
+                    Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_remote_pristine")[0], Theme.CLICK_INFO, Theme.PASSIVE)),
+                    Stream.concat(
+                        Stream.of(""),
+                        Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_remote_pristine")[1], Theme.CLICK_INFO, Theme.PASSIVE))
+                    )
+                )
+            ).toArray(String[]::new)
         );
 
         NETWORK_REMOTE_ULTIMATE = Theme.themedSlimefunItemStack(
             "NTW_REMOTE_ULTIMATE",
             getPreEnchantedItemStack(Material.GLOW_ITEM_FRAME, true, new Pair<>(VersionedEnchantment.LUCK_OF_THE_SEA, 1)),
             Theme.TOOL,
-            "终极网络远程访问器",
-            "远程打开绑定的网格",
-            "需要加载网格所在区块",
-            "",
-            MessageFormat.format("{0}Shift+右键点击 {1}普通网格以进行绑定", Theme.CLICK_INFO, Theme.PASSIVE),
-            "",
-            MessageFormat.format("{0}范围: {1}{2}", Theme.CLICK_INFO, Theme.PASSIVE, "跨维度")
+            Networks.getLocalization().getItemName("ntw_remote_ultimate"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_remote_ultimate")),
+                Stream.concat(
+                    Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_remote_ultimate")[0], Theme.CLICK_INFO, Theme.PASSIVE)),
+                    Stream.concat(
+                        Stream.of(""),
+                        Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_remote_ultimate")[1], Theme.CLICK_INFO, Theme.PASSIVE))
+                    )
+                )
+            ).toArray(String[]::new)
         );
 
         NETWORK_CRAYON = Theme.themedSlimefunItemStack(
             "NTW_CRAYON",
             new ItemStack(Material.RED_CANDLE),
-            Theme.TOOL,
-            "网络绘制器",
-            "当对着网络控制器使用时",
-            "可以让该网络中的方块展示出粒子效果"
+            Theme.TOOL,Networks.getLocalization().getItemName("ntw_crayon"),
+            Networks.getLocalization().getItemLore("ntw_crayon")
         );
 
         NETWORK_CONFIGURATOR = Theme.themedSlimefunItemStack(
             "NTW_CONFIGURATOR",
             new ItemStack(Material.BLAZE_ROD),
             Theme.TOOL,
-            "网络配置器",
-            "用于复制网络部件的设置",
-            "可复制带方向选择的网络方块的设置",
-            "",
-            MessageFormat.format("{0}右键点击: {1}{2}", Theme.CLICK_INFO, Theme.PASSIVE, "应用设置"),
-            MessageFormat.format("{0}Shift+右键点击: {1}{2}", Theme.CLICK_INFO, Theme.PASSIVE, "存储设置")
+            Networks.getLocalization().getItemName("ntw_configurator"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_configurator")),
+                Stream.concat(
+                    Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_configurator")[0], Theme.CLICK_INFO, Theme.PASSIVE)),
+                    Stream.concat(
+                        Stream.of(""),
+                        Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_configurator")[1], Theme.CLICK_INFO, Theme.PASSIVE))
+                    )
+                )
+            ).toArray(String[]::new)
         );
 
         NETWORK_WIRELESS_CONFIGURATOR = Theme.themedSlimefunItemStack(
             "NTW_WIRELESS_CONFIGURATOR",
             new ItemStack(Material.BLAZE_ROD),
             Theme.TOOL,
-            "网络无线配置器",
-            "用于储存一个接收器的位置,",
-            "并设置到发射器中.",
-            "",
-            MessageFormat.format("{0}右键点击: {1}{2}", Theme.CLICK_INFO, Theme.PASSIVE, "储存接收器的位置"),
-            MessageFormat.format("{0}Shift+右键点击: {1}{2}", Theme.CLICK_INFO, Theme.PASSIVE, "将位置设置到发射器中")
+            Networks.getLocalization().getItemName("ntw_wireless_configurator"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_wireless_configurator")),
+                Stream.concat(
+                    Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_wireless_configurator")[0], Theme.CLICK_INFO, Theme.PASSIVE)),
+                    Stream.concat(
+                        Stream.of(""),
+                        Stream.of(MessageFormat.format(Networks.getLocalization().getItemItemAditionalLore("ntw_wireless_configurator")[1], Theme.CLICK_INFO, Theme.PASSIVE))
+                    )
+                )
+            ).toArray(String[]::new)
         );
 
         NETWORK_RAKE_1 = Theme.themedSlimefunItemStack(
             "NTW_RAKE_1",
             new ItemStack(Material.TWISTING_VINES),
             Theme.TOOL,
-            "网络扳手 (1)",
-            "右键点击一个网络节点",
-            "可以立即破坏",
-            "",
-            LoreBuilder.usesLeft(250)
+            Networks.getLocalization().getItemName("ntw_rake_1"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_rake_1")),
+                Stream.of(LoreBuilder.usesLeft(250))
+            ).toArray(String[]::new)
+
         );
 
         NETWORK_RAKE_2 = Theme.themedSlimefunItemStack(
             "NTW_RAKE_2",
             new ItemStack(Material.WEEPING_VINES),
             Theme.TOOL,
-            "网络扳手 (2)",
-            "右键点击一个网络节点",
-            "可以立即破坏",
-            "",
-            LoreBuilder.usesLeft(1000)
+            Networks.getLocalization().getItemName("ntw_rake_2"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_rake_2")),
+                Stream.of(LoreBuilder.usesLeft(1000))
+            ).toArray(String[]::new)
         );
 
         NETWORK_RAKE_3 = Theme.themedSlimefunItemStack(
             "NTW_RAKE_3",
             getPreEnchantedItemStack(Material.WEEPING_VINES, true, new Pair<>(VersionedEnchantment.LUCK_OF_THE_SEA, 1)),
             Theme.TOOL,
-            "网络扳手 (3)",
-            "右键点击一个网络节点",
-            "可以立即破坏",
-            "",
-            LoreBuilder.usesLeft(9999)
+            Networks.getLocalization().getItemName("ntw_rake_3"),
+            Stream.concat(
+                Arrays.stream(Networks.getLocalization().getItemLore("ntw_rake_3")),
+                Stream.of(LoreBuilder.usesLeft(9999))
+            ).toArray(String[]::new)
         );
 
         NETWORK_DEBUG_STICK = Theme.themedSlimefunItemStack(
             "NTW_DEBUG_STICK",
             getPreEnchantedItemStack(Material.STICK, true, new Pair<>(VersionedEnchantment.LUCK_OF_THE_SEA, 1)),
             Theme.TOOL,
-            "网络调试棒",
-            "右键点击一个网络方块开启调试。"
+            Networks.getLocalization().getItemName("ntw_debug_stick"),
+            Networks.getLocalization().getItemLore("ntw_debug_stick")
         );
     }
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/groups/MainFlexGroup.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/groups/MainFlexGroup.java
@@ -1,5 +1,6 @@
 package io.github.sefiraat.networks.slimefun.groups;
 
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.slimefun.NetworksItemGroups;
 import io.github.sefiraat.networks.utils.Theme;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -29,8 +30,8 @@ public class MainFlexGroup extends FlexItemGroup {
     private static final ItemStack DOCS_ITEM_STACK = Theme.themedItemStack(
         Material.BOOK,
         Theme.GUIDE,
-        "附属 Wiki",
-        "点击获取网络的 Wiki 链接"
+        Networks.getLocalization().getMessage("documentation_wiki"),
+        Networks.getLocalization().getStringArray("messages.documentation_wiki_lore")
     );
 
     private static final int GUIDE_BACK = 1;
@@ -102,7 +103,7 @@ public class MainFlexGroup extends FlexItemGroup {
         // Docs
         menu.replaceExistingItem(DOCS, DOCS_ITEM_STACK);
         menu.addMenuClickHandler(DOCS, (player1, i1, itemStack1, clickAction) -> {
-            final TextComponent link = new TextComponent("单击此处访问Wiki");
+            final TextComponent link = new TextComponent(Networks.getLocalization().getMessage("click_view_wiki"));
             link.setColor(ChatColor.YELLOW);
             link.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://slimefun-addons-wiki.guizhanss.cn/networks/"));
             player.spigot().sendMessage(link);

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/AdminDebuggable.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/AdminDebuggable.java
@@ -3,6 +3,8 @@ package io.github.sefiraat.networks.slimefun.network;
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.utils.Theme;
+import io.github.thebusybiscuit.slimefun4.api.network.Network;
+
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
@@ -26,9 +28,9 @@ public interface AdminDebuggable {
         final boolean isDebug = isDebug(location);
         final boolean nextState = !isDebug;
         setDebug(location, nextState);
-        player.sendMessage(Theme.SUCCESS + "该方块的调试模式已设置为：" + nextState + "。");
+        player.sendMessage(Theme.SUCCESS + Networks.getLocalization().getMessage("debug_for_item_set_to") + "：" + nextState + "。");
         if (nextState) {
-            player.sendMessage(Theme.SUCCESS + "该模式将持续至服务器关闭，或者手动关闭。");
+            player.sendMessage(Theme.SUCCESS + Networks.getLocalization().getMessage("last_restart_off"));
         }
     }
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkAutoCrafter.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkAutoCrafter.java
@@ -2,6 +2,7 @@ package io.github.sefiraat.networks.slimefun.network;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NetworkRoot;
 import io.github.sefiraat.networks.network.NodeDefinition;
 import io.github.sefiraat.networks.network.NodeType;
@@ -52,11 +53,11 @@ public class NetworkAutoCrafter extends NetworkObject {
     private static final int OUTPUT_SLOT = 16;
 
     public static final CustomItemStack BLUEPRINT_BACKGROUND_STACK = new CustomItemStack(
-        Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + "合成蓝图"
+        Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + Networks.getLocalization().getMessage("craft_blueprint")
     );
 
     public static final CustomItemStack OUTPUT_BACKGROUND_STACK = new CustomItemStack(
-        Material.GREEN_STAINED_GLASS_PANE, Theme.PASSIVE + "输出"
+        Material.GREEN_STAINED_GLASS_PANE, Theme.PASSIVE + Networks.getLocalization().getMessage("output")
     );
 
     private final int chargePerCraft;

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlV.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlV.java
@@ -54,7 +54,7 @@ public class NetworkControlV extends NetworkDirectional {
     private final Set<BlockPosition> blockCache = new HashSet<>();
 
     public static final CustomItemStack TEMPLATE_BACKGROUND_STACK = new CustomItemStack(
-        Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + "粘贴物品模版"
+        Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + Networks.getLocalization().getMessage("paste_match_template")
     );
 
     public NetworkControlV(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlX.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkControlX.java
@@ -55,8 +55,8 @@ public class NetworkControlX extends NetworkDirectional {
 
     public static final CustomItemStack TEMPLATE_BACKGROUND_STACK = new CustomItemStack(
         Material.BLUE_STAINED_GLASS_PANE,
-        Theme.PASSIVE + "剪切物品模版",
-        Theme.PASSIVE + "留空将剪切任何方块"
+        Theme.PASSIVE + Networks.getLocalization().getMessage("cut_match_template"),
+        Theme.PASSIVE + Networks.getLocalization().getMessage("cut_empty")
     );
     private static final Particle.DustOptions DUST_OPTIONS = new Particle.DustOptions(Color.GRAY, 1);
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkController.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkController.java
@@ -3,6 +3,7 @@ package io.github.sefiraat.networks.slimefun.network;
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NetworkNode;
 import io.github.sefiraat.networks.network.NetworkRoot;
 import io.github.sefiraat.networks.network.NodeDefinition;
@@ -113,7 +114,7 @@ public class NetworkController extends NetworkObject {
 
     @Override
     protected void cancelPlace(PlayerRightClickEvent event) {
-        event.getPlayer().sendMessage(Theme.ERROR.getColor() + "This network already has a controller!");
+        event.getPlayer().sendMessage(Theme.ERROR.getColor() + Networks.getLocalization().getMessage("already_has_controller"));
         event.cancel();
     }
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkDirectional.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkDirectional.java
@@ -3,6 +3,7 @@ package io.github.sefiraat.networks.slimefun.network;
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NodeType;
 import io.github.sefiraat.networks.utils.NetworkUtils;
 import io.github.sefiraat.networks.utils.Theme;
@@ -318,7 +319,7 @@ public abstract class NetworkDirectional extends NetworkObject {
     public static ItemStack getDirectionalSlotPane(@Nonnull BlockFace blockFace, @Nonnull SlimefunItem slimefunItem, boolean active) {
         final ItemStack displayStack = new CustomItemStack(
             slimefunItem.getItem(),
-            Theme.PASSIVE + "设置朝向: " + blockFace.name() + " (" + ChatColor.stripColor(slimefunItem.getItemName()) + ")"
+            Theme.PASSIVE + Networks.getLocalization().getMessage("direction") + ": " + blockFace.name() + " (" + ChatColor.stripColor(slimefunItem.getItemName()) + ")"
         );
         final ItemMeta itemMeta = displayStack.getItemMeta();
         if (active) {
@@ -326,8 +327,8 @@ public abstract class NetworkDirectional extends NetworkObject {
             itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         }
         itemMeta.setLore(List.of(
-            Theme.CLICK_INFO + "左键点击: " + Theme.PASSIVE + "设置朝向",
-            Theme.CLICK_INFO + "Shift+左键点击: " + Theme.PASSIVE + "打开目标方块"
+            Theme.CLICK_INFO + Networks.getLocalization().getMessage("left_click") + ": " + Theme.PASSIVE + Networks.getLocalization().getMessage("set_direction"),
+            Theme.CLICK_INFO + "Shift+" + Networks.getLocalization().getMessage("left_click") + ": " + Theme.PASSIVE + Networks.getLocalization().getMessage("open_target_block")
         ));
         displayStack.setItemMeta(itemMeta);
         return displayStack;
@@ -338,7 +339,7 @@ public abstract class NetworkDirectional extends NetworkObject {
         if (blockMaterial.isItem() && !blockMaterial.isAir()) {
             final ItemStack displayStack = new CustomItemStack(
                 blockMaterial,
-                Theme.PASSIVE + "设置朝向 " + blockFace.name() + " (" + MaterialHelper.getName(blockMaterial) + ")"
+                Theme.PASSIVE + Networks.getLocalization().getMessage("direction") + " " + blockFace.name() + " (" + MaterialHelper.getName(blockMaterial) + ")"
             );
             final ItemMeta itemMeta = displayStack.getItemMeta();
             if (active) {
@@ -346,8 +347,8 @@ public abstract class NetworkDirectional extends NetworkObject {
                 itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             }
             itemMeta.setLore(List.of(
-                Theme.CLICK_INFO + "左键点击: " + Theme.PASSIVE + "设置朝向",
-                Theme.CLICK_INFO + "Shift+左键点击: " + Theme.PASSIVE + "打开目标方块"
+                Theme.CLICK_INFO + Networks.getLocalization().getMessage("left_click") + ": " + Theme.PASSIVE + Networks.getLocalization().getMessage("set_direction"),
+                Theme.CLICK_INFO + "Shift+" + Networks.getLocalization().getMessage("left_click") + ": " + Theme.PASSIVE + Networks.getLocalization().getMessage("open_target_block")
             ));
             displayStack.setItemMeta(itemMeta);
             return displayStack;
@@ -355,7 +356,7 @@ public abstract class NetworkDirectional extends NetworkObject {
             Material material = active ? Material.GREEN_STAINED_GLASS_PANE : Material.RED_STAINED_GLASS_PANE;
             return new CustomItemStack(
                 material,
-                ChatColor.GRAY + "设置朝向: " + blockFace.name()
+                ChatColor.GRAY + Networks.getLocalization().getMessage("set_direction") + ": " + blockFace.name()
             );
         }
     }

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkEncoder.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkEncoder.java
@@ -1,6 +1,7 @@
 package io.github.sefiraat.networks.slimefun.network;
 
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NetworkRoot;
 import io.github.sefiraat.networks.network.NodeDefinition;
 import io.github.sefiraat.networks.network.NodeType;
@@ -49,11 +50,11 @@ public class NetworkEncoder extends NetworkObject {
     private static final int CHARGE_COST = 20000;
 
     public static final CustomItemStack BLUEPRINT_BACK_STACK = new CustomItemStack(
-        Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + "空白蓝图"
+        Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + Networks.getLocalization().getMessage("blank_blueprint")
     );
 
     public static final CustomItemStack ENCODE_STACK = new CustomItemStack(
-        Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + "点击此处进行编码"
+        Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + Networks.getLocalization().getMessage("click_to_encode")
     );
 
     public NetworkEncoder(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
@@ -110,21 +111,21 @@ public class NetworkEncoder extends NetworkObject {
         final long networkCharge = root.getRootPower();
 
         if (networkCharge < CHARGE_COST) {
-            player.sendMessage(Theme.WARNING + "网络中的电力不足，无法完成该任务");
+            player.sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("not_enough_network_power_fulfill_task"));
             return;
         }
 
         final ItemStack outputStack = blockMenu.getItemInSlot(OUTPUT_SLOT);
 
         if (outputStack != null && outputStack.getType() != Material.AIR) {
-            player.sendMessage(Theme.WARNING + "需要清空输出栏");
+            player.sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("output_slot_empty"));
             return;
         }
 
         ItemStack blueprint = blockMenu.getItemInSlot(BLANK_BLUEPRINT_SLOT);
 
         if (!(SlimefunItem.getByItem(blueprint) instanceof CraftingBlueprint)) {
-            player.sendMessage(Theme.WARNING + "你需要提供一个空的合成蓝图");
+            player.sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("provide_blank_blueprint"));
             return;
         }
 
@@ -157,7 +158,7 @@ public class NetworkEncoder extends NetworkObject {
 
         // If no item crafted OR result doesn't fit, escape
         if (crafted.getType() == Material.AIR) {
-            player.sendMessage(Theme.WARNING + "这似乎不是一个有效的配方");
+            player.sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("doesnot_look_valid_recipe"));
             return;
         }
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkExport.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkExport.java
@@ -3,6 +3,7 @@ package io.github.sefiraat.networks.slimefun.network;
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NodeDefinition;
 import io.github.sefiraat.networks.network.NodeType;
 import io.github.sefiraat.networks.network.stackcaches.ItemRequest;
@@ -41,12 +42,12 @@ public class NetworkExport extends NetworkObject {
 
     private static final CustomItemStack TEST_BACKDROP_STACK = new CustomItemStack(
         Material.GREEN_STAINED_GLASS_PANE,
-        Theme.SUCCESS + "指定输出物品"
+        Theme.SUCCESS + Networks.getLocalization().getMessage("export_matching")
     );
 
     private static final CustomItemStack OUTPUT_BACKDROP_STACK = new CustomItemStack(
         Material.ORANGE_STAINED_GLASS_PANE,
-        Theme.SUCCESS + "输出栏"
+        Theme.SUCCESS + Networks.getLocalization().getMessage("output_slot")
     );
 
     private final ItemSetting<Integer> tickRate;

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkGreedyBlock.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkGreedyBlock.java
@@ -1,5 +1,6 @@
 package io.github.sefiraat.networks.slimefun.network;
 
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NodeType;
 import io.github.sefiraat.networks.slimefun.NetworkSlimefunItems;
 import io.github.sefiraat.networks.utils.Theme;
@@ -34,12 +35,12 @@ public class NetworkGreedyBlock extends NetworkObject {
 
     private static final CustomItemStack TEMPLATE_BACKGROUND_STACK = new CustomItemStack(
         Material.GREEN_STAINED_GLASS_PANE,
-        Theme.SUCCESS + "需要阻断的物品"
+        Theme.SUCCESS + Networks.getLocalization().getMessage("import_matching")
     );
 
     private static final CustomItemStack STORAGE_BACKGROUND_STACK = new CustomItemStack(
         Material.ORANGE_STAINED_GLASS_PANE,
-        Theme.SUCCESS + "物品存储"
+        Theme.SUCCESS + Networks.getLocalization().getMessage("output_slot")
     );
 
     public NetworkGreedyBlock(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkObject.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkObject.java
@@ -3,6 +3,7 @@ package io.github.sefiraat.networks.slimefun.network;
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NetworkRoot;
 import io.github.sefiraat.networks.network.NodeDefinition;
 import io.github.sefiraat.networks.network.NodeType;
@@ -153,7 +154,7 @@ public abstract class NetworkObject extends SlimefunItem implements AdminDebugga
     }
 
     protected void cancelPlace(PlayerRightClickEvent event) {
-        event.getPlayer().sendMessage(Theme.ERROR.getColor() + "This placement would connect two controllers!");
+        event.getPlayer().sendMessage(Theme.ERROR.getColor() + Networks.getLocalization().getMessage("placement_would_connect_two_controllers"));
         event.cancel();
     }
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkPowerDisplay.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkPowerDisplay.java
@@ -2,6 +2,7 @@ package io.github.sefiraat.networks.slimefun.network;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NetworkRoot;
 import io.github.sefiraat.networks.network.NodeDefinition;
 import io.github.sefiraat.networks.network.NodeType;
@@ -34,8 +35,8 @@ public class NetworkPowerDisplay extends NetworkObject {
 
     private static final CustomItemStack EMPTY = new CustomItemStack(
         Material.RED_STAINED_GLASS_PANE,
-        Theme.CLICK_INFO + "状态",
-        Theme.PASSIVE + "未连接"
+        Theme.CLICK_INFO + Networks.getLocalization().getMessage("status"),
+        Theme.PASSIVE + Networks.getLocalization().getMessage("disconnected")
     );
 
     public NetworkPowerDisplay(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
@@ -100,8 +101,8 @@ public class NetworkPowerDisplay extends NetworkObject {
     private static CustomItemStack getChargeStack(long charge) {
         return new CustomItemStack(
             Material.GREEN_STAINED_GLASS_PANE,
-            Theme.CLICK_INFO + "状态",
-            Theme.PASSIVE + "网络电力: " + charge + "J"
+            Theme.CLICK_INFO + Networks.getLocalization().getMessage("status"),
+            Theme.PASSIVE + Networks.getLocalization().getMessage("current_network_charge") + ": " + charge + "J"
         );
     }
 }

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkPurger.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkPurger.java
@@ -3,6 +3,7 @@ package io.github.sefiraat.networks.slimefun.network;
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NodeDefinition;
 import io.github.sefiraat.networks.network.NodeType;
 import io.github.sefiraat.networks.network.stackcaches.ItemRequest;
@@ -42,7 +43,7 @@ public class NetworkPurger extends NetworkObject {
 
     private static final CustomItemStack TEST_BACKDROP_STACK = new CustomItemStack(
         Material.GREEN_STAINED_GLASS_PANE,
-        Theme.SUCCESS + "指定需要清除的物品"
+        Theme.SUCCESS + Networks.getLocalization().getMessage("purge_matching")
     );
 
     private final ItemSetting<Integer> tickRate;

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkPusher.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkPusher.java
@@ -2,6 +2,7 @@ package io.github.sefiraat.networks.slimefun.network;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NodeDefinition;
 import io.github.sefiraat.networks.network.NodeType;
 import io.github.sefiraat.networks.network.stackcaches.ItemRequest;
@@ -38,7 +39,7 @@ public class NetworkPusher extends NetworkDirectional {
     private static final int DOWN_SLOT = 32;
 
     public static final CustomItemStack TEMPLATE_BACKGROUND_STACK = new CustomItemStack(
-        Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + "指定需要推送的物品"
+        Material.BLUE_STAINED_GLASS_PANE, Theme.PASSIVE + Networks.getLocalization().getMessage("push_matching")
     );
 
     public NetworkPusher(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkQuantumStorage.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkQuantumStorage.java
@@ -2,6 +2,8 @@ package io.github.sefiraat.networks.slimefun.network;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
+
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.stackcaches.QuantumCache;
 import io.github.sefiraat.networks.utils.Keys;
 import io.github.sefiraat.networks.utils.StackUtils;
@@ -68,30 +70,30 @@ public class NetworkQuantumStorage extends SlimefunItem implements DistinctiveIt
 
     private static final ItemStack BACK_INPUT = new CustomItemStack(
         Material.GREEN_STAINED_GLASS_PANE,
-        Theme.PASSIVE + "输入"
+        Theme.PASSIVE + Networks.getLocalization().getMessage("input")
     );
 
     private static final ItemStack BACK_ITEM = new CustomItemStack(
         Material.BLUE_STAINED_GLASS_PANE,
-        Theme.PASSIVE + "当前存储的物品"
+        Theme.PASSIVE + Networks.getLocalization().getMessage("item_stored")
     );
 
     private static final ItemStack NO_ITEM = new CustomItemStack(
         Material.RED_STAINED_GLASS_PANE,
-        Theme.ERROR + "未指定物品",
-        Theme.PASSIVE + "拿起物品并点击下方的按钮",
-        Theme.PASSIVE + "以设置量子存储保存的物品"
+        Theme.ERROR + Networks.getLocalization().getMessage("no_registered_item"),
+        Theme.PASSIVE + Networks.getLocalization().getMessage("click_icon_to_register0"),
+        Theme.PASSIVE + Networks.getLocalization().getMessage("click_icon_to_register1")
     );
 
     private static final ItemStack SET_ITEM = new CustomItemStack(
         Material.LIME_STAINED_GLASS_PANE,
-        Theme.SUCCESS + "设置",
-        Theme.PASSIVE + "拿起物品并点击这里以设置物品",
-        Theme.CLICK_INFO + "Shift+左键点击" + Theme.PASSIVE + "切换满载清空输入");
+        Theme.SUCCESS + Networks.getLocalization().getMessage("set_item"),
+        Theme.PASSIVE + Networks.getLocalization().getMessage("drag_top_pane_register"),
+        Theme.CLICK_INFO + "Shift+" + Networks.getLocalization().getMessage("left_click") + Theme.PASSIVE + Networks.getLocalization().getMessage("change_void"));
 
     private static final ItemStack BACK_OUTPUT = new CustomItemStack(
         Material.ORANGE_STAINED_GLASS_PANE,
-        Theme.PASSIVE + "输出"
+        Theme.PASSIVE + Networks.getLocalization().getMessage("output")
     );
 
     private static final int[] INPUT_SLOTS = new int[]{0, 2};
@@ -208,7 +210,7 @@ public class NetworkQuantumStorage extends SlimefunItem implements DistinctiveIt
 
         final QuantumCache cache = CACHES.get(blockMenu.getLocation());
         if (cache == null || cache.getAmount() > 0) {
-            player.sendMessage(Theme.WARNING + "量子存储必须为空才能更换物品");
+            player.sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("quantum_empty_before_change"));
             return;
         }
         itemStack.setAmount(1);
@@ -433,8 +435,8 @@ public class NetworkQuantumStorage extends SlimefunItem implements DistinctiveIt
             final ItemMeta itemMeta = itemStack.getItemMeta();
             final List<String> lore = itemMeta.hasLore() ? itemMeta.getLore() : new ArrayList<>();
             lore.add("");
-            lore.add(Theme.CLICK_INFO + "满载清空输入: " + Theme.PASSIVE + BooleanHelper.enabledOrDisabled(cache.isVoidExcess()));
-            lore.add(Theme.CLICK_INFO + "数量: " + Theme.PASSIVE + cache.getAmount());
+            lore.add(Theme.CLICK_INFO + Networks.getLocalization().getMessage("voiding") + ": " + Theme.PASSIVE + BooleanHelper.enabledOrDisabled(cache.isVoidExcess()));
+            lore.add(Theme.CLICK_INFO + Networks.getLocalization().getMessage("amount") + ": " + Theme.PASSIVE + cache.getAmount());
             itemMeta.setLore(lore);
             itemStack.setItemMeta(itemMeta);
             itemStack.setAmount(1);

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkQuantumWorkbench.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkQuantumWorkbench.java
@@ -1,6 +1,8 @@
 package io.github.sefiraat.networks.slimefun.network;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
+
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.stackcaches.QuantumCache;
 import io.github.sefiraat.networks.utils.Keys;
 import io.github.sefiraat.networks.utils.Theme;
@@ -44,7 +46,7 @@ public class NetworkQuantumWorkbench extends SlimefunItem {
 
     private static final CustomItemStack CRAFT_BUTTON_STACK = new CustomItemStack(
         Material.CRAFTING_TABLE,
-        Theme.CLICK_INFO + "点击进行量子纠缠"
+        Theme.CLICK_INFO + Networks.getLocalization().getMessage("click_entangle")
     );
 
     private static final Map<ItemStack[], ItemStack> RECIPES = new HashMap<>();
@@ -54,8 +56,8 @@ public class NetworkQuantumWorkbench extends SlimefunItem {
         Theme.themedItemStack(
             Material.BRAIN_CORAL_BLOCK,
             Theme.MACHINE,
-            "网络量子工作台",
-            "在量子工作台中制作"
+            Networks.getLocalization().getItemName("quantum_workbench"),
+            Networks.getLocalization().getItemLore("quantum_workbench")
         ),
         NetworkQuantumWorkbench::addRecipe
     );

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkVanillaGrabber.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkVanillaGrabber.java
@@ -105,15 +105,15 @@ public class NetworkVanillaGrabber extends NetworkDirectional {
         boolean wildChests = Networks.getSupportedPluginManager().isWildChests();
         boolean isChest = wildChests && WildChestsAPI.getChest(targetBlock.getLocation()) != null;
 
-        sendDebugMessage(block.getLocation(), "WildChests 已安装：" + wildChests);
-        sendDebugMessage(block.getLocation(), "该方块是否被 WildChest 判断为方块：" + isChest);
+        sendDebugMessage(block.getLocation(), Networks.getLocalization().getMessage("whildchest_detected") + "：" + wildChests);
+        sendDebugMessage(block.getLocation(), Networks.getLocalization().getMessage("whildchest_detected_as_chest") + "：" + isChest);
 
         if (wildChests && isChest) {
-            sendDebugMessage(block.getLocation(), "WildChest 测试失败！");
+            sendDebugMessage(block.getLocation(), Networks.getLocalization().getMessage("whildchest_test_failed"));
             return;
         }
 
-        sendDebugMessage(block.getLocation(), "WildChest 测试通过。");
+        sendDebugMessage(block.getLocation(), Networks.getLocalization().getMessage("whildchest_test_passed"));
         final Inventory inventory = holder.getInventory();
 
         if (inventory instanceof FurnaceInventory furnaceInventory) {

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkVanillaPusher.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkVanillaPusher.java
@@ -104,18 +104,18 @@ public class NetworkVanillaPusher extends NetworkDirectional {
         boolean wildChests = Networks.getSupportedPluginManager().isWildChests();
         boolean isChest = wildChests && WildChestsAPI.getChest(targetBlock.getLocation()) != null;
 
-        sendDebugMessage(block.getLocation(), "WildChests 已安装：" + wildChests);
-        sendDebugMessage(block.getLocation(), "该方块是否被 WildChest 判断为方块：" + isChest);
+        sendDebugMessage(block.getLocation(), Networks.getLocalization().getMessage("whildchest_detected") + "：" + wildChests);
+        sendDebugMessage(block.getLocation(), Networks.getLocalization().getMessage("whildchest_detected_as_chest") + "：" + isChest);
 
         if (inventory instanceof FurnaceInventory furnace) {
             handleFurnace(stack, furnace);
         } else if (inventory instanceof BrewerInventory brewer) {
             handleBrewingStand(stack, brewer);
         } else if (wildChests && isChest) {
-            sendDebugMessage(block.getLocation(), "WildChest 测试失败！");
+            sendDebugMessage(block.getLocation(), Networks.getLocalization().getMessage("whildchest_test_failed"));
             return;
         } else if (InvUtils.fits(holder.getInventory(), stack)) {
-            sendDebugMessage(block.getLocation(), "WildChest 测试成功。");
+            sendDebugMessage(block.getLocation(), Networks.getLocalization().getMessage("whildchest_test_passed"));
             holder.getInventory().addItem(stack);
             stack.setAmount(0);
         }

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkWirelessReceiver.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkWirelessReceiver.java
@@ -2,6 +2,7 @@ package io.github.sefiraat.networks.slimefun.network;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NodeDefinition;
 import io.github.sefiraat.networks.network.NodeType;
 import io.github.sefiraat.networks.slimefun.NetworkSlimefunItems;
@@ -38,7 +39,7 @@ public class NetworkWirelessReceiver extends NetworkObject {
 
     private static final CustomItemStack RECEIVED_BACKGROUND_STACK = new CustomItemStack(
         Material.GREEN_STAINED_GLASS_PANE,
-        Theme.SUCCESS + "接收的物品"
+        Theme.SUCCESS + Networks.getLocalization().getMessage("received_items")
     );
 
     public NetworkWirelessReceiver(ItemGroup itemGroup,

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkWirelessTransmitter.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/NetworkWirelessTransmitter.java
@@ -3,6 +3,7 @@ package io.github.sefiraat.networks.slimefun.network;
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NodeDefinition;
 import io.github.sefiraat.networks.network.NodeType;
 import io.github.sefiraat.networks.network.stackcaches.ItemRequest;
@@ -45,7 +46,7 @@ public class NetworkWirelessTransmitter extends NetworkObject {
 
     private static final CustomItemStack TEMPLATE_BACKGROUND_STACK = new CustomItemStack(
         Material.GREEN_STAINED_GLASS_PANE,
-        Theme.SUCCESS + "发送的物品"
+        Theme.SUCCESS + Networks.getLocalization().getMessage("transmit_items_matching")
     );
 
     private static final String LINKED_LOCATION_KEY_X = "linked-location-x";

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/grid/AbstractGrid.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/grid/AbstractGrid.java
@@ -4,6 +4,7 @@ import com.github.houbb.pinyin.constant.enums.PinyinStyleEnum;
 import com.github.houbb.pinyin.util.PinyinHelper;
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.GridItemRequest;
 import io.github.sefiraat.networks.network.NetworkRoot;
 import io.github.sefiraat.networks.network.NodeDefinition;
@@ -52,22 +53,22 @@ public abstract class AbstractGrid extends NetworkObject {
 
     private static final CustomItemStack PAGE_PREVIOUS_STACK = new CustomItemStack(
         Material.RED_STAINED_GLASS_PANE,
-        Theme.CLICK_INFO.getColor() + "上一页"
+        Theme.CLICK_INFO.getColor() + Networks.getLocalization().getMessage("previous_page")
     );
 
     private static final CustomItemStack PAGE_NEXT_STACK = new CustomItemStack(
         Material.RED_STAINED_GLASS_PANE,
-        Theme.CLICK_INFO.getColor() + "下一页"
+        Theme.CLICK_INFO.getColor() + Networks.getLocalization().getMessage("next_page")
     );
 
     private static final CustomItemStack CHANGE_SORT_STACK = new CustomItemStack(
         Material.BLUE_STAINED_GLASS_PANE,
-        Theme.CLICK_INFO.getColor() + "更改排序方式"
+        Theme.CLICK_INFO.getColor() + Networks.getLocalization().getMessage("change_sorting")
     );
 
     private static final CustomItemStack FILTER_STACK = new CustomItemStack(
         Material.NAME_TAG,
-        Theme.CLICK_INFO.getColor() + "设置过滤器 (右键点击以清除)"
+        Theme.CLICK_INFO.getColor() + Networks.getLocalization().getMessage("set_filter")
     );
 
     private static final Comparator<Map.Entry<ItemStack, Integer>> ALPHABETICAL_SORT = Comparator.comparing(
@@ -234,13 +235,13 @@ public abstract class AbstractGrid extends NetworkObject {
             gridCache.setFilter(null);
         } else {
             player.closeInventory();
-            player.sendMessage(Theme.WARNING + "请输入你想要过滤的物品名称(显示名)或类型");
+            player.sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("type_to_filter"));
             ChatUtils.awaitInput(player, s -> {
                 if (s.isBlank()) {
                     return;
                 }
                 gridCache.setFilter(s.toLowerCase(Locale.ROOT));
-                player.sendMessage(Theme.SUCCESS + "已启用过滤器");
+                player.sendMessage(Theme.SUCCESS + Networks.getLocalization().getMessage("filter_applied"));
             });
         }
         return false;
@@ -370,7 +371,7 @@ public abstract class AbstractGrid extends NetworkObject {
 
     @Nonnull
     private static List<String> getLoreAddition(int amount) {
-        final MessageFormat format = new MessageFormat("{0}数量: {1}{2}", Locale.ROOT);
+        final MessageFormat format = new MessageFormat(Networks.getLocalization().getMessage("format_amount"), Locale.ROOT);
         return List.of(
             "",
             format.format(new Object[] {Theme.CLICK_INFO.getColor(), Theme.PASSIVE.getColor(), amount}, new StringBuffer(), null).toString()

--- a/src/main/java/io/github/sefiraat/networks/slimefun/network/grid/NetworkCraftingGrid.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/network/grid/NetworkCraftingGrid.java
@@ -1,6 +1,7 @@
 package io.github.sefiraat.networks.slimefun.network.grid;
 
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.GridItemRequest;
 import io.github.sefiraat.networks.network.NodeDefinition;
 import io.github.sefiraat.networks.network.SupportedRecipes;
@@ -52,9 +53,9 @@ public class NetworkCraftingGrid extends AbstractGrid {
 
     private static final CustomItemStack CRAFT_BUTTON_STACK = new CustomItemStack(
         Material.CRAFTING_TABLE,
-        Theme.CLICK_INFO.getColor() + "合成",
-        Theme.CLICK_INFO + "左键点击: " + Theme.PASSIVE + "合成",
-        Theme.CLICK_INFO + "Shift+左键点击: " + Theme.PASSIVE + "将合成台内物品送回网络"
+        Theme.CLICK_INFO.getColor() + Networks.getLocalization().getMessage("craft"),
+        Theme.CLICK_INFO + Networks.getLocalization().getMessage("left_click") + ": " + Theme.PASSIVE + Networks.getLocalization().getMessage("try_craft"),
+        Theme.CLICK_INFO + "Shift+" + Networks.getLocalization().getMessage("left_click") + ": " + Theme.PASSIVE + Networks.getLocalization().getMessage("try_return_items")
     );
 
     private static final Map<Location, GridCache> CACHE_MAP = new HashMap<>();

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/CanCooldown.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/CanCooldown.java
@@ -1,5 +1,6 @@
 package io.github.sefiraat.networks.slimefun.tools;
 
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.utils.StackUtils;
 import io.github.sefiraat.networks.utils.Theme;
 import org.bukkit.entity.Player;
@@ -26,7 +27,7 @@ public interface CanCooldown {
     default boolean canBeUsed(@Nullable Player player, ItemStack itemStack) {
         if (StackUtils.isOnCooldown(itemStack)) {
             if (player != null) {
-                player.sendMessage(Theme.WARNING + "This is still on cooldown");
+                player.sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("still_cooldown"));
             }
             return false;
         } else {

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/CraftingBlueprint.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/CraftingBlueprint.java
@@ -1,5 +1,6 @@
 package io.github.sefiraat.networks.slimefun.tools;
 
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.stackcaches.BlueprintInstance;
 import io.github.sefiraat.networks.utils.Keys;
 import io.github.sefiraat.networks.utils.Theme;
@@ -37,18 +38,18 @@ public class CraftingBlueprint extends UnplaceableBlock implements DistinctiveIt
         DataTypeMethods.setCustom(itemMeta, Keys.BLUEPRINT_INSTANCE, PersistentCraftingBlueprintType.TYPE, new BlueprintInstance(recipe, output));
         List<String> lore = new ArrayList<>();
 
-        lore.add(Theme.CLICK_INFO + "已指定配方");
+        lore.add(Theme.CLICK_INFO + Networks.getLocalization().getMessage("assigned_recipe"));
 
         for (ItemStack item : recipe) {
             if (item == null) {
-                lore.add(Theme.PASSIVE + "空");
+                lore.add(Theme.PASSIVE + Networks.getLocalization().getMessage("nothing"));
                 continue;
             }
             lore.add(Theme.PASSIVE + ChatColor.stripColor(ItemStackHelper.getDisplayName(item)));
         }
 
         lore.add("");
-        lore.add(Theme.CLICK_INFO + "输出物品");
+        lore.add(Theme.CLICK_INFO + Networks.getLocalization().getMessage("outputting"));
 
         lore.add(Theme.PASSIVE + ChatColor.stripColor(ItemStackHelper.getDisplayName(output)));
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkAdminDebugger.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkAdminDebugger.java
@@ -1,6 +1,8 @@
 package io.github.sefiraat.networks.slimefun.tools;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
+
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.slimefun.network.AdminDebuggable;
 import io.github.sefiraat.networks.utils.Theme;
 import io.github.thebusybiscuit.slimefun4.api.events.PlayerRightClickEvent;
@@ -38,7 +40,7 @@ public class NetworkAdminDebugger extends SlimefunItem {
             final Player player = e.getPlayer();
             final SlimefunItem slimefunItem = StorageCacheUtils.getSfItem(block.getLocation());
             if (!player.isOp()) {
-                player.sendMessage(Theme.ERROR + "该物品只能由 OP 玩家使用。");
+                player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("debug_op"));
                 return;
             }
             if (slimefunItem instanceof AdminDebuggable debuggable) {

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkCard.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkCard.java
@@ -1,5 +1,6 @@
 package io.github.sefiraat.networks.slimefun.tools;
 
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.stackcaches.CardInstance;
 import io.github.sefiraat.networks.utils.Keys;
 import io.github.sefiraat.networks.utils.Theme;
@@ -49,12 +50,12 @@ public class NetworkCard extends SlimefunItem implements DistinctiveItem {
 
                 e.cancel();
                 if (card.getAmount() > 1) {
-                    player.sendMessage(Theme.WARNING + "请单独拿出一张内存卡，不要堆叠");
+                    player.sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("unstack_cards_before"));
                     return;
                 }
 
                 if (isBlacklisted(stackToSet)) {
-                    player.sendMessage(Theme.WARNING + "该物品无法存储至内存卡中");
+                    player.sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("cards_cannot_stored"));
                     return;
                 }
 
@@ -69,7 +70,7 @@ public class NetworkCard extends SlimefunItem implements DistinctiveItem {
                     );
 
                     if (cardInstance.getAmount() > 0) {
-                        e.getPlayer().sendMessage(Theme.WARNING + "只有空内存卡才能分配物品");
+                        e.getPlayer().sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("cards_must_empty_assign"));
                         return;
                     }
 

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkConfigurator.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkConfigurator.java
@@ -2,6 +2,7 @@ package io.github.sefiraat.networks.slimefun.tools;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import de.jeff_media.morepersistentdatatypes.DataType;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.slimefun.network.NetworkDirectional;
 import io.github.sefiraat.networks.utils.Keys;
 import io.github.sefiraat.networks.utils.NetworkUtils;
@@ -47,7 +48,7 @@ public class NetworkConfigurator extends SlimefunItem {
                                 NetworkUtils.applyConfig(directional, e.getItem(), blockMenu, player);
                             }
                         } else {
-                            player.sendMessage(Theme.ERROR + "你必须指向一个带方向选择的网络方块");
+                            player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("must_target_direcional"));
                         }
                     }
                     e.cancel();
@@ -59,7 +60,7 @@ public class NetworkConfigurator extends SlimefunItem {
         final BlockFace blockFace = NetworkDirectional.getSelectedFace(blockMenu.getLocation());
 
         if (blockFace == null) {
-            player.sendMessage(Theme.ERROR + "该方块没有指定朝向");
+            player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("directional_not_have_set"));
             return;
         }
 
@@ -83,6 +84,6 @@ public class NetworkConfigurator extends SlimefunItem {
 
         DataTypeMethods.setCustom(itemMeta, Keys.FACE, DataType.STRING, blockFace.name());
         itemStack.setItemMeta(itemMeta);
-        player.sendMessage(Theme.SUCCESS + "已复制设置");
+        player.sendMessage(Theme.SUCCESS + Networks.getLocalization().getMessage("config_copied"));
     }
 }

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkCrayon.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkCrayon.java
@@ -1,6 +1,8 @@
 package io.github.sefiraat.networks.slimefun.tools;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
+
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.slimefun.network.NetworkController;
 import io.github.sefiraat.networks.utils.Theme;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -38,10 +40,10 @@ public class NetworkCrayon extends SlimefunItem {
     public void toggleCrayon(@Nonnull Block block, @Nonnull Player player) {
         if (NetworkController.hasCrayon(block.getLocation())) {
             NetworkController.removeCrayon(block.getLocation());
-            player.sendMessage(Theme.WARNING + "已关闭网络绘制");
+            player.sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("crayon_removed"));
         } else {
             NetworkController.addCrayon(block.getLocation());
-            player.sendMessage(Theme.SUCCESS + "已开启网络绘制");
+            player.sendMessage(Theme.SUCCESS + Networks.getLocalization().getMessage("crayon_added"));
         }
     }
 }

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkProbe.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkProbe.java
@@ -1,6 +1,8 @@
 package io.github.sefiraat.networks.slimefun.tools;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
+
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NetworkRoot;
 import io.github.sefiraat.networks.slimefun.network.NetworkController;
 import io.github.sefiraat.networks.utils.Theme;
@@ -94,43 +96,43 @@ public class NetworkProbe extends SlimefunItem implements CanCooldown {
             final ChatColor p = Theme.PASSIVE.getColor();
 
             player.sendMessage("------------------------------");
-            player.sendMessage("         网络 - 组件统计        ");
+            player.sendMessage(Networks.getLocalization().getMessage("network_sumary"));
             player.sendMessage("------------------------------");
 
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网桥", p, bridges}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络监测器", p, monitors}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络入口", p, importers}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络出口", p, exporters}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网格", p, grids}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络单元", p, cells}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络内存清除器", p, wipers}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络抓取器", p, grabbers}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络推送器", p, pushers}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络剪切器", p, cutters}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络粘贴器", p, pasters}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络吸尘器", p, vacuums}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络清除器", p, purgers}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络自动合成机", p, crafters}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络能源节点", p, powerNodes}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络插口", p, powerOutlets}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络电表", p, powerDisplays}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络配方编码器", p, encoders}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络阻断器", p, greedyBlocks}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络无线发射器", p, wirelessTransmitters}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "网络无线接收器", p, wirelessReceivers}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("bridges"), p, bridges}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("monitors"), p, monitors}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("importers"), p, importers}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("exportes"), p, exporters}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("grids"), p, grids}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("cells"), p, cells}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("wipers"), p, wipers}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("grabbers"), p, grabbers}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("puschers"), p, pushers}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("cutters"), p, cutters}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("pasters"), p, pasters}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("vacuums"), p, vacuums}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("purgers"), p, purgers}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("crafters"), p, crafters}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("power_nodes"), p, powerNodes}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("power_outlets"), p, powerOutlets}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("power_displays"), p, powerDisplays}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("encoders"), p, encoders}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("greedy_blocks"), p, greedyBlocks}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("wireless_transmitters"), p, wirelessTransmitters}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("wireless_receivers"), p, wirelessReceivers}, new StringBuffer(), null).toString());
 
             player.sendMessage("------------------------------");
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "物品类型数量", p, distinctItems}, new StringBuffer(), null).toString());
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "累计物品数量", p, totalItems}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("distinct_items"), p, distinctItems}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("total_items"), p, totalItems}, new StringBuffer(), null).toString());
 
             player.sendMessage("------------------------------");
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "总电量", p, rootPower}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("root_power"), p, rootPower}, new StringBuffer(), null).toString());
 
             player.sendMessage("------------------------------");
-            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, "累计节点", p, nodeCount + "/" + root.getMaxNodes()}, new StringBuffer(), null).toString());
+            player.sendMessage(MESSAGE_FORMAT.format(new Object[]{c, Networks.getLocalization().getMessage("total_nodes"), p, nodeCount + "/" + root.getMaxNodes()}, new StringBuffer(), null).toString());
             if (root.isOverburdened()) {
-                player.sendMessage(Theme.ERROR + "警告: " + Theme.PASSIVE +
-                    "该网络已达到最大节点数量限制，部分节点可能会无法正常工作。请减少网络节点的数量。"
+                player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("warning") + ": " + Theme.PASSIVE +
+                    Networks.getLocalization().getMessage("maximum_node_limit")
                 );
             }
         }

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkRemote.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkRemote.java
@@ -4,6 +4,7 @@ import com.xzavier0722.mc.plugin.slimefun4.storage.callback.IAsyncReadCallback;
 import com.xzavier0722.mc.plugin.slimefun4.storage.controller.SlimefunBlockData;
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import de.jeff_media.morepersistentdatatypes.DataType;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.slimefun.network.grid.NetworkGrid;
 import io.github.sefiraat.networks.utils.Keys;
 import io.github.sefiraat.networks.utils.Theme;
@@ -15,6 +16,8 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
+
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
@@ -55,7 +58,7 @@ public class NetworkRemote extends SlimefunItem {
                             ) {
                                 setGrid(e.getItem(), block, player);
                             } else {
-                                player.sendMessage(Theme.ERROR + "必须连接到一个网格 (不能是带合成的)");
+                                player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("set_to_grid"));
                             }
                         }
                     } else {
@@ -70,7 +73,7 @@ public class NetworkRemote extends SlimefunItem {
         final ItemMeta itemMeta = itemStack.getItemMeta();
         DataTypeMethods.setCustom(itemMeta, KEY, DataType.LOCATION, block.getLocation());
         itemStack.setItemMeta(itemMeta);
-        player.sendMessage(Theme.SUCCESS + "网格已绑定至远程访问器");
+        player.sendMessage(Theme.SUCCESS + Networks.getLocalization().getMessage("bound_to_remote"));
     }
 
     public static void tryOpenGrid(@Nonnull ItemStack itemStack, @Nonnull Player player, int range) {
@@ -80,7 +83,7 @@ public class NetworkRemote extends SlimefunItem {
         if (location != null) {
 
             if (!location.getWorld().isChunkLoaded(location.getBlockX() / 16, location.getBlockZ() / 16)) {
-                player.sendMessage(Theme.ERROR + "绑定的网格所在区块没有加载");
+                player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("bound_not_loaded"));
                 return;
             }
 
@@ -92,10 +95,10 @@ public class NetworkRemote extends SlimefunItem {
             ) {
                 openGrid(location, player);
             } else {
-                player.sendMessage(Theme.ERROR + "绑定的网格不在范围内");
+                player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("bound_not_reach"));
             }
         } else {
-            player.sendMessage(Theme.ERROR + "该远程访问器没有绑定网格");
+            player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("remote_not_bound"));
         }
     }
 
@@ -103,7 +106,7 @@ public class NetworkRemote extends SlimefunItem {
         SlimefunBlockData blockData = StorageCacheUtils.getBlock(location);
 
         if(blockData == null) {
-            player.sendMessage(Theme.ERROR + "无法找到绑定的网格");
+            player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("bound_not_found"));
         }
         else {
             StorageCacheUtils.executeAfterLoad(blockData, () -> {
@@ -111,7 +114,7 @@ public class NetworkRemote extends SlimefunItem {
                     && Slimefun.getProtectionManager().hasPermission(player, location, Interaction.INTERACT_BLOCK)) {
                     blockData.getBlockMenu().open(player);
                 } else {
-                    player.sendMessage(Theme.ERROR + "无法找到绑定的网格");
+                    player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("bound_not_found"));
                 }
             }, false);
         }

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkRemote.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkRemote.java
@@ -101,14 +101,20 @@ public class NetworkRemote extends SlimefunItem {
 
     public static void openGrid(@Nonnull Location location, @Nonnull Player player) {
         SlimefunBlockData blockData = StorageCacheUtils.getBlock(location);
-        StorageCacheUtils.executeAfterLoad(blockData, () -> {
-            if (SlimefunItem.getById(blockData.getSfId()) instanceof NetworkGrid
-                && Slimefun.getProtectionManager().hasPermission(player, location, Interaction.INTERACT_BLOCK)) {
-                blockData.getBlockMenu().open(player);
-            } else {
-                player.sendMessage(Theme.ERROR + "无法找到绑定的网格");
-            }
-        }, false);
+
+        if(blockData == null) {
+            player.sendMessage(Theme.ERROR + "无法找到绑定的网格");
+        }
+        else {
+            StorageCacheUtils.executeAfterLoad(blockData, () -> {
+                if (SlimefunItem.getById(blockData.getSfId()) instanceof NetworkGrid
+                    && Slimefun.getProtectionManager().hasPermission(player, location, Interaction.INTERACT_BLOCK)) {
+                    blockData.getBlockMenu().open(player);
+                } else {
+                    player.sendMessage(Theme.ERROR + "无法找到绑定的网格");
+                }
+            }, false);
+        }
     }
 
     public int getRange() {

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkWirelessConfigurator.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkWirelessConfigurator.java
@@ -2,6 +2,7 @@ package io.github.sefiraat.networks.slimefun.tools;
 
 import com.xzavier0722.mc.plugin.slimefun4.storage.util.StorageCacheUtils;
 import de.jeff_media.morepersistentdatatypes.DataType;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.slimefun.network.NetworkWirelessReceiver;
 import io.github.sefiraat.networks.slimefun.network.NetworkWirelessTransmitter;
 import io.github.sefiraat.networks.utils.Keys;
@@ -54,7 +55,7 @@ public class NetworkWirelessConfigurator extends SlimefunItem {
                                 setReceiver(heldItem, blockMenu, player);
                             }
                         } else {
-                            player.sendMessage(Theme.ERROR + "必须对着网络无线方块使用。");
+                            player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("must_target_wireless_block"));
                         }
                     }
                     e.cancel();
@@ -72,17 +73,17 @@ public class NetworkWirelessConfigurator extends SlimefunItem {
         final Location location = PersistentDataAPI.get(itemMeta, TARGET_LOCATION, DataType.LOCATION);
 
         if (location == null) {
-            player.sendMessage(Theme.ERROR + "需要先设置接收器位置。");
+            player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("no_wireless_been_set"));
             return;
         }
 
         if (location.getWorld() != blockMenu.getLocation().getWorld()) {
-            player.sendMessage(Theme.ERROR + "网络无线接收器在不同的世界中。");
+            player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("wireless_different_world"));
             return;
         }
 
         transmitter.addLinkedLocation(blockMenu.getBlock(), location);
-        player.sendMessage(Theme.SUCCESS + "已设置网络无线发射器。");
+        player.sendMessage(Theme.SUCCESS + Networks.getLocalization().getMessage("wireless_transmitters_location"));
     }
 
     private void setReceiver(@Nonnull ItemStack itemStack, @Nonnull BlockMenu blockMenu, @Nonnull Player player) {
@@ -90,6 +91,6 @@ public class NetworkWirelessConfigurator extends SlimefunItem {
         final ItemMeta itemMeta = itemStack.getItemMeta();
         PersistentDataAPI.set(itemMeta, TARGET_LOCATION, DataType.LOCATION, location);
         itemStack.setItemMeta(itemMeta);
-        player.sendMessage(Theme.SUCCESS + "已存储网络无线接收器的位置。");
+        player.sendMessage(Theme.SUCCESS + Networks.getLocalization().getMessage("wireless_been_set"));
     }
 }

--- a/src/main/java/io/github/sefiraat/networks/utils/NetworkUtils.java
+++ b/src/main/java/io/github/sefiraat/networks/utils/NetworkUtils.java
@@ -3,6 +3,7 @@ package io.github.sefiraat.networks.utils;
 import de.jeff_media.morepersistentdatatypes.DataType;
 
 import io.github.sefiraat.networks.NetworkStorage;
+import io.github.sefiraat.networks.Networks;
 import io.github.sefiraat.networks.network.NetworkNode;
 import io.github.sefiraat.networks.network.NodeDefinition;
 import io.github.sefiraat.networks.network.NodeType;
@@ -39,12 +40,12 @@ public class NetworkUtils {
         final String string = DataTypeMethods.getCustom(itemMeta, Keys.FACE, DataType.STRING);
 
         if (string == null) {
-            player.sendMessage(Theme.ERROR + "Direction: " + Theme.PASSIVE + "Not supplied");
+            player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("direction") + ": " + Theme.PASSIVE + Networks.getLocalization().getMessage("not_supplied"));
             return;
         }
 
         directional.setDirection(blockMenu, BlockFace.valueOf(string));
-        player.sendMessage(Theme.ERROR + "Direction: " + Theme.PASSIVE + "Successfully applied");
+        player.sendMessage(Theme.ERROR + Networks.getLocalization().getMessage("direction") + ": " + Theme.PASSIVE + Networks.getLocalization().getMessage("successfully_applied"));
 
 
         if (directional.getItemSlots().length > 0) {
@@ -67,21 +68,21 @@ public class NetworkUtils {
                             final ItemStack stackClone = StackUtils.getAsQuantity(stack, 1);
                             stack.setAmount(stack.getAmount() - 1);
                             blockMenu.replaceExistingItem(directional.getItemSlots()[i], stackClone);
-                            player.sendMessage(Theme.SUCCESS + "Item [" + i + "]: " + Theme.PASSIVE + "Item added into filter");
+                            player.sendMessage(Theme.SUCCESS + Networks.getLocalization().getMessage("item") + " [" + i + "]: " + Theme.PASSIVE + Networks.getLocalization().getMessage("item_added_filter"));
                             worked = true;
                             break;
                         }
                     }
                     if (!worked) {
-                        player.sendMessage(Theme.WARNING + "Item [" + i + "]: " + Theme.PASSIVE + "Not enough items to fill filter");
+                        player.sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("item") + " [" + i + "]: " + Theme.PASSIVE + Networks.getLocalization().getMessage("not_enough_item_filter"));
                     }
                 } else if (directional instanceof NetworkPusher) {
-                    player.sendMessage(Theme.WARNING + "Item [" + i + "]: " + Theme.PASSIVE + "No item in stored config");
+                    player.sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("item") + " [" + i + "]: " + Theme.PASSIVE + Networks.getLocalization().getMessage("no_item_stored_config"));
                 }
                 i++;
             }
         } else {
-            player.sendMessage(Theme.WARNING + "Items: " + Theme.PASSIVE + "No items in stored config");
+            player.sendMessage(Theme.WARNING + Networks.getLocalization().getMessage("items") + ": " + Theme.PASSIVE + Networks.getLocalization().getMessage("no_items_stored_config"));
         }
     }
 

--- a/src/main/java/io/github/sefiraat/networks/utils/Theme.java
+++ b/src/main/java/io/github/sefiraat/networks/utils/Theme.java
@@ -1,5 +1,6 @@
 package io.github.sefiraat.networks.utils;
 
+import io.github.sefiraat.networks.Networks;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import lombok.Getter;
@@ -16,22 +17,22 @@ import java.util.List;
 
 @Getter
 public enum Theme {
-    WARNING(ChatColor.YELLOW, "警告"),
-    ERROR(ChatColor.RED, "错误"),
-    NOTICE(ChatColor.WHITE, "通知"),
-    PASSIVE(ChatColor.GRAY, ""),
-    SUCCESS(ChatColor.GREEN, "成功"),
-    MAIN(ChatColor.of("#21588f"), "网络"),
-    CLICK_INFO(ChatColor.of("#e4ed32"), "单击此处"),
-    RESEARCH(ChatColor.of("#a60e03"), "研究"),
-    CRAFTING(ChatColor.of("#dbcea9"), "合成材料"),
-    MACHINE(ChatColor.of("#3295a8"), "机器"),
-    TOOL(ChatColor.of("#6b32a8"), "工具"),
-    MECHANISM(ChatColor.of("#3295a8"), "装置"),
-    FUEL(ChatColor.of("#112211"), "染料"),
-    MATERIAL_CLASS(ChatColor.of("#a4c2ba"), "材料"),
-    RECIPE_TYPE(ChatColor.of("#ffe89c"), "配方类型"),
-    GUIDE(ChatColor.of("#444444"), "指南");
+    WARNING(ChatColor.YELLOW, Networks.getLocalization().getMessage("warning")),
+    ERROR(ChatColor.RED, Networks.getLocalization().getMessage("error")),
+    NOTICE(ChatColor.WHITE, Networks.getLocalization().getMessage("notice")),
+    PASSIVE(ChatColor.GRAY, Networks.getLocalization().getMessage("passive")),
+    SUCCESS(ChatColor.GREEN, Networks.getLocalization().getMessage("success")),
+    MAIN(ChatColor.of("#21588f"), Networks.getLocalization().getMessage("main")),
+    CLICK_INFO(ChatColor.of("#e4ed32"), Networks.getLocalization().getMessage("click_info")),
+    RESEARCH(ChatColor.of("#a60e03"), Networks.getLocalization().getMessage("research")),
+    CRAFTING(ChatColor.of("#dbcea9"), Networks.getLocalization().getMessage("crafting")),
+    MACHINE(ChatColor.of("#3295a8"), Networks.getLocalization().getMessage("machine")),
+    TOOL(ChatColor.of("#6b32a8"), Networks.getLocalization().getMessage("tool")),
+    MECHANISM(ChatColor.of("#3295a8"), Networks.getLocalization().getMessage("mechanism")),
+    FUEL(ChatColor.of("#112211"), Networks.getLocalization().getMessage("fuel")),
+    MATERIAL_CLASS(ChatColor.of("#a4c2ba"), Networks.getLocalization().getMessage("material_class")),
+    RECIPE_TYPE(ChatColor.of("#ffe89c"), Networks.getLocalization().getMessage("recipe_type")),
+    GUIDE(ChatColor.of("#444444"), Networks.getLocalization().getMessage("guide"));
 
     @Getter
     protected static final Theme[] cachedValues = values();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,2 +1,3 @@
 # 启用自动更新 (从构建站自动更新，重启服务器后新版本生效)
 auto-update: true
+lang: zh-CN

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -1,0 +1,698 @@
+categories:
+  ash: asdasd2
+
+items:
+  ntw_stone_chunk_seed:
+    name: Stone Chunk Seed
+    lore:
+    - This seed, when fully grown, will
+    - provide Stone Chunks when
+    - harvested.
+    aditional_lore:
+    - Nether Grass (or better)
+  ntw_synthetic_seed:
+    name: Synthetic Seed
+    lore:
+    - This seed does nothing.
+    aditional_lore:
+    - Nether Grass (or better)
+  ntw_synthetic_emerald_seed:
+    name: Synthetic Emerald Seed
+    lore:
+    - This seed, when fully grown, will
+    - provide Synthetic Emeralds when
+    - harvested.
+    aditional_lore:
+    - Voracious Dirt (or better)
+  ntw_synthetic_diamond_seed:
+    name: Synthetic Diamond Seed
+    lore:
+    - This seed, when fully grown, will
+    - provide Synthetic Diamonds when
+    - harvested.
+    aditional_lore:
+    - Voracious Dirt (or better)
+  ntw_fragmented_seed:
+    name: Fragmented Seed
+    lore:
+    - This seed, when fully grown, will
+    - provide Synthetic Emerald Shards when
+    - harvested.
+    aditional_lore:
+    - Voracious Dirt (or better)
+  quantum_workbench:
+    name: Quantum Workbench
+    lore:
+    - Crafted using the Quantum Workbench
+  
+  ntw_synthetic_emerald_shard:
+    name: Synthetic Emerald Shard
+    lore:
+    - A shard of synthetic emerald that
+    - is the backbone for information
+    - transference.
+  ntw_optic_glass:
+    name: Optic Glass
+    lore:
+    - A simple glass that is able to
+    - transfer small bits of information.
+  ntw_optic_cable:
+    name: Optic Cable
+    lore:
+    - A simple wire that is able to
+    - transfer large bits of information.
+  ntw_optic_star:
+    name: Optic Star
+    lore:
+    - A crystalline star structure that
+    - can transfer large bits of information.
+  ntw_radioactive_optic_star:
+    name: Radioactive Optic Star
+    lore:
+    - A crystalline star structure that
+    - can store insane amounts of information.
+  ntw_shrinking_base:
+    name: Shrinking Base
+    lore:
+    - An advanced construct able to make
+    - big things go small.
+  ntw_simple_nanobots:
+    name: Simple Nanobots
+    lore:
+    - Teeny Tiny little bots that can
+    - help you with precise tasks.
+  ntw_advanced_nanobots:
+    name: Advanced Nanobots
+    lore:
+    - Teeny Tiny little bots that can
+    - help you with precise tasks.
+    - This version is smarter and faster.
+  ntw_ai_core:
+    name: A.I. Core
+    lore:
+    - A burgeoning artificial intelligence
+    - resides within this weak shell.
+  ntw_empowered_ai_core:
+    name: Empowered A.I. Core
+    lore:
+    - A flourishing artificial intelligence
+    - resides within this shell.
+  ntw_pristine_ai_core:
+    name: Pristine A.I. Core
+    lore:
+    - A perfected artificial intelligence
+    - resides within this defined shell.
+  ntw_interdimensional_presence:
+    name: Interdimensional Presence
+    lore:
+    - An artificial intelligence that has
+    - grown too powerful for just a
+    - single dimension.
+  ntw_controller:
+    name: Network Controller
+    lore:
+    - The Network controller is the brain
+    - for the whole network. Max 1 per network.
+  ntw_bridge:
+    name: Network Bridge
+    lore:
+    - The bridge allows you to cheaply
+    - connect network objects together.
+  ntw_monitor:
+    name: Network Monitor
+    lore:
+    - The Network Monitor allows simple
+    - import/export interaction with adjacent
+    - objects.
+    - ''
+    - 'Currently Supports:'
+    - Infinity Barrels
+    - Network Shells
+  ntw_import:
+    name: Network Importer
+    lore:
+    - The Network Importer brings any
+    - item inside it into the network, up
+    - to 9 stacks per SF tick.
+    - Accepts items in from cargo.
+  ntw_export:
+    name: Network Exporter
+    lore:
+    - The Network Exporter can be set to
+    - constantly export 1 stack of any
+    - given item.
+    - Accepts item withdrawal from cargo.
+  ntw_grabber:
+    name: Network Grabber
+    lore:
+    - The Network Grabber will try
+    - to grab the first item it finds
+    - from within the selected machine.
+  ntw_pusher:
+    name: Network Pusher
+    lore:
+    - The Network Pusher will try
+    - to push a matching item from a
+    - given item into the chosen machine.
+  ntw_control_x:
+    name: 'Network Control: X'
+    lore:
+    - 'The Network Control: X will try'
+    - to 'cut' a block out of the world
+    - and put it into the Network.
+    - Only works on Vanilla blocks without
+    - inventories.
+    - ''
+    aditional_lore:
+    - '{0}Network Drain: {1}{2}/cut'
+  ntw_control_v:
+    name: 'Network Control: V'
+    lore:
+    - 'The Network Control: V will try'
+    - to 'paste' a block from the Network
+    - into the world.
+    - Only works with Vanilla blocks.
+    - ''
+    aditional_lore:
+    - '{0}Network Drain: {1}{2}/paste'
+  ntw_vacuum:
+    name: Network Vacuum
+    lore:
+    - The Network Vacuum will suck
+    - items into itself within a
+    - 4 x 4 range centered on itself.
+    - Vacuumed items will try to push
+    - into the Network.
+    - ''
+    aditional_lore:
+    - '{0}Network Drain: {1}{2}/tick'
+  ntw_vanilla_grabber:
+    name: Network Vanilla Grabber
+    lore:
+    - The Network Vanilla Pusher will try
+    - to grab the first possible item from
+    - the chosen vanilla inventory.
+    - You need to grab items from this
+    - node using a Grabber.
+  ntw_vanilla_pusher:
+    name: Network Vanilla Pusher
+    lore:
+    - The Network Vanilla Pusher will try
+    - to push any item inside itself into
+    - the chosen vanilla inventory.
+    - You need to push items into this
+    - node from a Pusher.
+  ntw_network_wireless_transmitter:
+    name: Network Wireless Transmitter
+    lore:
+    - The Network Wireless Transmitter will
+    - try to transmit any item inside itself
+    - to a linked Network Wireless Receiver
+    - located within the same world.
+    - Use the Wireless Configurator to
+    - setup the Wireless Transmitter.
+    - Requires 500 Network Power per transfer.
+  ntw_network_wireless_receiver:
+    name: Network Wireless Receiver
+    lore:
+    - The Network Wireless Receiver is
+    - able to receive items from a linked
+    - wireless transmitter located within
+    - the same world.
+    - It will try to push received items
+    - into the Network each tick.
+  ntw_trash:
+    name: Network Purger
+    lore:
+    - The Network Purger will pull
+    - matching items from the network
+    - and instantly void them.
+    - Use with great care!
+  ntw_grid:
+    name: Network Grid
+    lore:
+    - The Network Grid shows you all
+    - the items you have in the network
+    - and lets you insert or withdraw
+    - directly.
+  ntw_crafting_grid:
+    name: Network Crafting Grid
+    lore:
+    - The Network Crafting Grid acts
+    - like a normal grid but displays less
+    - items but allows crafting using items
+    - directly from the network.
+  ntw_cell:
+    name: Network Cell
+    lore:
+    - The Network Cell is a large
+    - (double chest) inventory that can
+    - be accessed both from the network
+    - and in the world.
+  ntw_greedy_block:
+    name: Network Greedy Block
+    lore:
+    - The Network Greedy Block can
+    - be set to one item which it will
+    - then greedily hold on to a single
+    - stack of. If more incoming items
+    - do not fit, they will not enter
+    - the network.
+  ntw_quantum_workbench:
+    name: Network Quantum Workbench
+    lore:
+    - Allows the crafting of Quantum Storages.
+  ntw_quantum_storage_1:
+    name: Network Quantum Storage (4K)
+    lore:
+    - Stores 4096 items
+    - ''
+    - Stores items in mass quantities within
+    - a quantum singularity.
+  ntw_quantum_storage_2:
+    name: Network Quantum Storage (32K)
+    lore:
+    - Stores 32768 items
+    - ''
+    - Stores items in mass quantities within
+    - a quantum singularity.
+  ntw_quantum_storage_3:
+    name: Network Quantum Storage (262K)
+    lore:
+    - Stores 262144 items
+    - ''
+    - Stores items in mass quantities within
+    - a quantum singularity.
+  ntw_quantum_storage_4:
+    name: Network Quantum Storage (2M)
+    lore:
+    - Stores 2097152 items
+    - ''
+    - Stores items in mass quantities within
+    - a quantum singularity.
+  ntw_quantum_storage_5:
+    name: Network Quantum Storage (16M)
+    lore:
+    - Stores 16777216 items
+    - ''
+    - Stores items in mass quantities within
+    - a quantum singularity.
+  ntw_quantum_storage_6:
+    name: Network Quantum Storage (134M)
+    lore:
+    - Stores 134217728 items
+    - ''
+    - Stores items in mass quantities within
+    - a quantum singularity.
+  ntw_quantum_storage_7:
+    name: Network Quantum Storage (1B)
+    lore:
+    - Stores 1073741824 items
+    - ''
+    - Stores items in mass quantities within
+    - a quantum singularity.
+  ntw_quantum_storage_8:
+    name: Network Quantum Storage (∞)
+    lore:
+    - Stores ∞ items... almost
+    - ''
+    - Stores items in mass quantities within
+    - a quantum singularity.
+  ntw_capacitor_1:
+    name: Network Capacitor (1)
+    lore:
+    - The Network Capacitor can take
+    - power in and store it for use
+    - within the network.
+    - ''
+    aditional_lore:
+    - '{0}Capacity: {1}{2}'
+  ntw_capacitor_2:
+    name: Network Capacitor (2)
+    lore:
+    - The Network Capacitor can take
+    - power in and store it for use
+    - within the network.
+    - ''
+    aditional_lore:
+    - '{0}Capacity: {1}{2}'
+  ntw_capacitor_3:
+    name: Network Capacitor (3)
+    lore:
+    - The Network Capacitor can take
+    - power in and store it for use
+    - within the network.
+    - ''
+    aditional_lore:
+    - '{0}Capacity: {1}{2}'
+  ntw_capacitor_4:
+    name: Network Capacitor (4)
+    lore:
+    - The Network Capacitor can take
+    - power in and store it for use
+    - within the network.
+    - ''
+    aditional_lore:
+    - '{0}Capacity: {1}{2}'
+  ntw_power_outlet_1:
+    name: Network Power Outlet (1)
+    lore:
+    - The Network Capacitor can take
+    - power from the Network to power
+    - machines or feed back into an
+    - EnergyNet network.
+    - ''
+    - Operates at a 20% loss rate.
+    - ''
+    aditional_lore:
+    - '{0}Max Transfer: {1}{2}'
+  ntw_power_outlet_2:
+    name: Network Power Outlet (2)
+    lore:
+    - The Network Capacitor can take
+    - power from the Network to power.
+    - machines or feed back into an.
+    - EnergyNet network..
+    - ''
+    - Operates at a 20% loss rate.
+    - ''
+    aditional_lore:
+    - '{0}Max Transfer: {1}{2}'
+  ntw_power_display:
+    name: Network Power Display
+    lore:
+    - The Network Power Display will
+    - display the power in the network.
+    - Simple, right?
+  ntw_recipe_encoder:
+    name: Network Recipe Encoder
+    lore:
+    - Used to form a Crafting Blueprint
+    - from input items.
+    - ''
+    aditional_lore:
+    - '{0}Network Drain: {1}{2}/encode'
+  ntw_auto_crafter:
+    name: Network Auto Crafter
+    lore:
+    - The Network Auto Crafter accepts
+    - a crafting blueprint. When the
+    - blueprint output item is requested
+    - while there is none in the network
+    - it will be crafted if you have
+    - materials.
+    - ''
+    aditional_lore:
+    - '{0}Network Drain: {1}{2}/craft'
+  ntw_auto_crafter_withholding:
+    name: Network Auto Crafter (Withholding)
+    lore:
+    - The Network Auto Crafter accepts
+    - a crafting blueprint. When the
+    - blueprint output item is requested
+    - while there is none in the network
+    - it will be crafted if you have
+    - materials.
+    - ''
+    - A Withholding Crafter will keep
+    - a stack in the output and stop
+    - crafting. The stack can been seen
+    - in the Network and also allows for
+    - cargo.
+    - ''
+    aditional_lore:
+    - '{0}Network Drain: {1}{2}/craft'
+  ntw_crafting_blueprint:
+    name: Crafting Blueprint
+    lore:
+    - A blank blueprint that can
+    - be used to store a crafting
+    - recipe.
+    aditional_lore:
+    - ''
+  ntw_probe:
+    name: Network Probe
+    lore:
+    - When used on a controller, this will
+    - show the nodes on the network.
+    aditional_lore:
+    - ''
+  ntw_remote:
+    name: Network Remote
+    lore:
+    - Opens a bound grid wirelessly.
+    - The grid must be chunk loaded.
+    - ''
+    aditional_lore:
+    - '{0}Shift+Right click {1}Normal grid for binding'
+    - '{0}Range: {1}{2}'
+  ntw_remote_empowered:
+    name: Network Remote Empowered
+    lore:
+    - Opens a bound grid wirelessly.
+    - The grid must be chunk loaded.
+    - ''
+    aditional_lore:
+    - '{0}Shift+Right click {1}Normal grid for binding'
+    - '{0}Range: {1}{2}'
+  ntw_remote_pristine:
+    name: Network Remote Pristine
+    lore:
+    - Opens a bound grid wirelessly.
+    - The grid must be chunk loaded.
+    - ''
+    aditional_lore:
+    - '{0}Shift+Right click {1}Normal grid for binding'
+    - '{0}Range: {1}Unlimited (same world only)'
+  ntw_remote_ultimate:
+    name: Network Remote Ultimate
+    lore:
+    - Opens a bound grid wirelessly.
+    - The grid must be chunk loaded.
+    - ''
+    aditional_lore:
+    - '{0}Shift+Right click {1}Normal grid for binding'
+    - '{0}Range: {1}Cross-dimensional'
+  ntw_crayon:
+    name: Network Crayon
+    lore:
+    - When used on a controller, this will
+    - enable particle display from specific
+    - blocks when working.
+    - ''
+    aditional_lore:
+    - ''
+  ntw_configurator:
+    name: Network Configurator
+    lore:
+    - Used to copy and paste the
+    - configurations of directional
+    - interfaces.
+    - ''
+    aditional_lore:
+    - '{0}Right Click: {1}Apply Config'
+    - '{0}Shift Right Click: {1}Store Config'
+  ntw_wireless_configurator:
+    name: Network Wireless Configurator
+    lore:
+    - Used to store a Receiver location
+    - and then to apply to a Transmitter
+    - ''
+    aditional_lore:
+    - '{0}Right Click: {1}Store Receiver Location'
+    - '{0}Shift Right Click: {1}Set Location to Transmitter'
+  ntw_rake_1:
+    name: Network Rake (1)
+    lore:
+    - Right click a Network Object to
+    - break it instantly.
+    - ''
+    aditional_lore:
+    - ''
+  ntw_rake_2:
+    name: Network Rake (2)
+    lore:
+    - Right click a Network Object to
+    - break it instantly.
+    - ''
+    aditional_lore:
+    - ''
+  ntw_rake_3:
+    name: Network Rake (3)
+    lore:
+    - Right click a Network Object to
+    - break it instantly.
+    - ''
+    aditional_lore:
+    - ''
+  ntw_debug_stick:
+    name: Network Debug Stick
+    lore:
+    - Right click a Network Object to
+    - turn on debugging.
+    aditional_lore:
+    - ''
+
+messages:
+  need_guizhanlib_plugin: This plugin needs GuizhanLibPlugin to run! Get it in https://50l.cc/gzlib
+  
+  
+  need_netheo_plugin_update: You must update Netheopoiesis to allow Networks to add
+    relevant features
+  need_slimehud_plugin_update: You must update SlimeHUD to allow the network to add
+    relevant features.
+  hand_item_must_quantum_storage: Item in hand must be a Quantum Storage.
+  corrupted_quantum_storage: This card has either not been set to an item yet or is
+    a corrupted Quantum Storage.
+  item_updated: Item updated
+  empty: 'Empty'
+  cannot_instantiate_class: Cannot instantiate class
+  none: none
+  holding: Holding
+  amount: Amount
+  documentation_wiki: Documentation Wiki
+  documentation_wiki_lore:
+  - Click to get the link to the
+  - documentation Wiki for Networks
+  - and other Sefiraat addons.
+  click_view_wiki: To access the documentation Wiki, please click here
+  previous_page: Previous Page
+  next_page: Next Page
+  change_sorting: Change Sort Order
+  set_filter: Set Filter (Right Click to Clear)
+  type_to_filter: Type what you would like to filter this grid to
+  filter_applied: Filter applied
+  format_amount: '{0}Amount: {1}{2}'
+  craft: Craft
+  try_craft: Try to Craft
+  left_click: Left Click
+  try_return_items: Try to return items
+  debug_for_item_set_to: Debugging for this block has been set to
+  last_restart_off: It will last until a restart or you toggle it off.
+  craft_blueprint: Crafting Blueprint
+  output: Output
+  output_slot: Output Slot
+  input: Input
+  already_has_controller: This network already has a controller!
+  paste_match_template: Paste items matching template
+  cut_match_template: Cut items matching template.
+  cut_empty: Leaving blank will cut anything
+  direction: Direction
+  set_direction: Set Direction
+  open_target_block: Open Target Block
+  blank_blueprint: Blank Blueprint
+  click_to_encode: Click to encode when valid
+  not_enough_network_power_fulfill_task: Not enough Network power to fulfill this
+    task.
+  output_slot_empty: The output slot must be empty.
+  provide_blank_blueprint: You need to provide a blank blueprint
+  doesnot_look_valid_recipe: Doesn't look like this is a valid recipe.
+  export_matching: Export Item Matching
+  import_matching: Store items matching
+  purge_matching: Purge Item Matching
+  push_matching: Push items matching template
+  placement_would_connect_two_controllers: This placement would connect two controllers!
+  status: Status
+  disconnected: Disconnected
+  item_stored: Item Stored
+  no_registered_item: No Registered Item
+  click_icon_to_register0: Click the icon below while
+  click_icon_to_register1: holding an item to register it.
+  set_item: Set Item
+  drag_top_pane_register: Drag an item on top of this pane to register it.
+  change_void: to change voiding
+  quantum_empty_before_change: Quantum Storage must be empty before changing the set
+    item.
+  voiding: Voiding
+  click_entangle: Click to entangle
+  whildchest_detected: WildChests detected
+  whildchest_detected_as_chest: Block detected as chest
+  whildchest_test_failed: WildChest test failed, escaping
+  whildchest_test_passed: WildChest test passed.
+  received_items: Received items
+  transmit_items_matching: Transmit items matching
+  still_cooldown: This is still on cooldown
+  assigned_recipe: Assigned Recipe
+  nothing: Nothing
+  outputting: Outputting
+  debug_op: You can only use this tool as an op'd player.
+  unstack_cards_before: Unstack cards before assigning an item.
+  cards_cannot_stored: This type of item cannot be stored in a Network Card.
+  cards_must_empty_assign: A card must be empty before trying to assign an item.
+  must_target_direcional: Must target a directional Networks interface.
+  directional_not_have_set: This directional does not yet have a direction set
+  config_copied: Configuration copied.
+  crayon_removed: Crayon removed from network
+  crayon_added: Crayon added to network
+  network_sumary: '       Network Summary        '
+  bridges: Bridges
+  monitors: Monitors
+  importers: Importers
+  exportes: Exporters
+  grids: Grids
+  cells: Cells
+  wipers: Wipers
+  grabbers: Grabbers
+  puschers: Pushers
+  pasters: Pasters
+  cutters: Cutters
+  vacuums: Vacuums
+  purgers: Purgers
+  crafters: Crafters
+  power_nodes: Power Nodes
+  power_outlets: Power Outlets
+  power_displays: Power Displays
+  encoders: Encoders
+  greedy_blocks: Greedy Blocks
+  wireless_transmitters: Wireless Transmitters
+  wireless_receivers: Wireless Receivers
+  distinct_items: Distinct Items
+  total_items: Total Items
+  root_power: Root Power
+  total_nodes: Total Nodes
+  warning: Warning
+  error: Error
+  passive: ''
+  notice: Notice
+  success: Success
+  main: Alone
+  click_info: Click here
+  research: Research
+  crafting: Crafting Material
+  machine: Machine
+  tool: Tool
+  mechanism: Mechanism
+  fuel: Fossil Fuel
+  material_class: Material Class
+  recipe_type: Recipe Type
+  guide: Guide
+  maximum_node_limit: Your network has reached or exceeded the maximum node limit.
+    Nodes beyond the limit will not function, which nodes these are may not always
+    be the same. Reduce your total nodes.
+  set_to_grid: Must be set to a Network Grid (not crafting grid).
+  bound_to_remote: Grid has been bound to the remote.
+  bound_not_loaded: The bound grid is not loaded.
+  bound_not_reach: The bound grid is not within reach.
+  remote_not_bound: Remote is not bound to a grid.
+  bound_not_found: The bound grid can no longer be found.
+  must_target_wireless_block: Must target a Network Wireless block.
+  no_wireless_been_set: No Wireless Receiver has been set.
+  wireless_different_world: No Wireless Receiver has been set.
+  wireless_transmitters_location: Set Transmitter's receiver location.
+  wireless_been_set: Wireless Receiver set.
+  networks: Networks
+  crafting_materials: Crafting Materials
+  network_management_tools: Network Management Tools
+  network_items: Network Items
+  network_quantum_storage_devices: Network Quantum Storage Devices
+  disabled_items: Disabled/Removed Items
+  not_supplied: Not supplied
+  successfully_applied: Successfully applied
+  item: Item
+  items: Items
+  item_added_filter: Item added into filter
+  not_enough_item_filter: Not enough items to fill filter
+  no_item_stored_config: No item in stored config
+  no_items_stored_config: No items in stored config
+  unknown_error: Unknown/Error
+  current_network_charge: Current Network Charge

--- a/src/main/resources/lang/pt-BR.yml
+++ b/src/main/resources/lang/pt-BR.yml
@@ -1,0 +1,10 @@
+categories:
+  ash: asdasd2
+
+items:
+  asd: asdasd
+
+messages:
+  need_guizhanlib_plugin: "Este plugin requer o GuizhanLibPlugin para ser executado! Baixe aqui: https://50l.cc/gzlib"
+  need_netheo_plugin_update: Você deve atualizar o Netheopoiesis para permitir que o Networks adicione recursos relevantes.
+  need_slimehud_plugin_update: Você deve atualizar o SlimeHUD para permitir que o Networks adicione recursos relevantes.

--- a/src/main/resources/lang/zh-CN.yml
+++ b/src/main/resources/lang/zh-CN.yml
@@ -1,0 +1,642 @@
+categories:
+  ash: asdasd2
+
+items:
+  ntw_stone_chunk_seed:
+    name: 石块之种
+    lore:
+    - 这种植物成熟后,
+    - 收获时将获得石块.
+    aditional_lore:
+    - 下界草方块
+    - (或净化等级更高的)
+  ntw_synthetic_seed:
+    name: 人造之种
+    lore:
+    - 这个种子没有任何效果.
+    aditional_lore:
+    - 下界草方块
+    - (或净化等级更高的)
+  ntw_synthetic_emerald_seed:
+    name: 人造绿宝石之种
+    lore:
+    - 这种植物成熟后,
+    - 收获时将获得人造绿宝石.
+    aditional_lore:
+    - 贪婪泥土
+    - (或净化等级更高的)
+  ntw_synthetic_diamond_seed:
+    name: 人造钻石之种
+    lore:
+    - 这种植物成熟后,
+    - 收获时将获得人造钻石.
+    aditional_lore:
+    - 贪婪泥土
+    - (或净化等级更高的)
+  ntw_fragmented_seed:
+    name: 碎片之种
+    lore:
+    - 这种植物成熟后,
+    - 收获时将获得人造绿宝石碎片.
+    aditional_lore:
+    - 贪婪泥土
+    - (或净化等级更高的)
+  quantum_workbench:
+    name: 网络量子工作台
+    lore:
+    - 在量子工作台中制作
+  
+  ntw_synthetic_emerald_shard:
+    name: 人造绿宝石碎片
+    lore:
+    - 一块人造绿宝石的碎片
+    - 是信息传输的支柱
+  ntw_optic_glass:
+    name: 光学玻璃
+    lore:
+    - 能够传输少量信息的玻璃
+  ntw_optic_cable:
+    name: 光缆
+    lore:
+    - 能够传输大量信息的光缆
+  ntw_optic_star:
+    name: 光学之星
+    lore:
+    - 能够传输大量信息的星
+  ntw_radioactive_optic_star:
+    name: 放射性光学之星
+    lore:
+    - 能够传输几乎无限信息的星
+  ntw_shrinking_base:
+    name: 缩小底座
+    lore:
+    - 可以让大型物体变小的装置
+  ntw_simple_nanobots:
+    name: 简易纳米机器人
+    lore:
+    - 可以帮助你完成精密任务的微型机器人
+  ntw_advanced_nanobots:
+    name: 高级纳米机器人
+    lore:
+    - 可以帮助你完成精密任务的微型机器人
+    - 比简易版更智能，更高效
+  ntw_ai_core:
+    name: 人工智能核心
+    lore:
+    - 在脆弱外壳中的初代人工智能
+  ntw_empowered_ai_core:
+    name: 充能人工智能核心
+    lore:
+    - 在外壳中的高级人工智能
+  ntw_pristine_ai_core:
+    name: 古代人工智能核心
+    lore:
+    - 据说是从上古遗迹中挖掘出来的
+    - 完美级人工智能
+  ntw_interdimensional_presence:
+    name: 跨跃维度的存在
+    lore:
+    - 这种完美级的人工智能
+    - 甚至还掌握了跨越维度的能力
+  ntw_controller:
+    name: 网络控制器
+    lore:
+    - 网络控制器是网络的核心部分
+    - 每个网络最多有1个控制器
+  ntw_bridge:
+    name: 网桥
+    lore:
+    - 网桥用于连接不同的网络物品
+    - 来形成一个完整的网络
+  ntw_monitor:
+    name: 网络监视器
+    lore:
+    - 网络监视器可以与附近的方块交互
+    - 让指定方块可以接入网络
+    - ''
+    - 目前支持
+    - 无尽科技 - 存储单元
+    - 网络 - 量子存储
+  ntw_import:
+    name: 网络入口
+    lore:
+    - 网络入口会将其中的物品送入网络中
+    - 每个SF tick可传输最多9组物品
+    - 可接收来自货运网络的物品
+  ntw_export:
+    name: 网络出口
+    lore:
+    - 网络出口可以设置成
+    - 持续将1组指定的物品送出网络
+    - 可以使用货运网络从中提取物品
+  ntw_grabber:
+    name: 网络抓取器
+    lore:
+    - 网络抓取器会尝试从
+    - 指定的机器中抓取第一个物品
+  ntw_pusher:
+    name: 网络推送器
+    lore:
+    - 网络推送器会尝试将
+    - 指定的物品送入机器中
+  ntw_control_x:
+    name: 网络剪切器
+    lore:
+    - 网络剪切器会尝试将
+    - 方块从世界中"剪切"到网络中
+    - 仅支持原版非容器方块
+    - ''
+    aditional_lore:
+    - '{0}网络电力消耗: {1}每次操作 {2}J'
+  ntw_control_v:
+    name: 网络粘贴器
+    lore:
+    - 网络粘贴器会尝试将
+    - 方块从网络中"粘贴"到世界中
+    - 仅支持原版方块
+    - ''
+    aditional_lore:
+    - '{0}网络电力消耗: {1}每次操作 {2}J'
+  ntw_vacuum:
+    name: 网络吸尘器
+    lore:
+    - 网络吸尘器可以将周围
+    - 4x4范围内的掉落物品吸收
+    - 然后尝试将这些物品送入网络中
+    - ''
+    aditional_lore:
+    - '{0}网络电力消耗: {1}{2}J/粘液刻'
+  ntw_vanilla_grabber:
+    name: 网络原版容器抓取器
+    lore:
+    - 网络原版容器抓取器会尝试
+    - 抓取指定原版容器中的第一个物品.
+    - ''
+    - 该机器不能与网络直接交互,
+    - 你还需要一个网络抓取器
+    - 将本机器中的物品输入到网络中.
+  ntw_vanilla_pusher:
+    name: 网络原版容器推送器
+    lore:
+    - 网络原版容器推送器会尝试
+    - 推送其中的物品到指定原版容器中
+    - ''
+    - 该机器不能与网络直接交互,
+    - 你还需要一个网络推送器
+    - 将网络中的物品推送到本机器中.
+  ntw_network_wireless_transmitter:
+    name: 网络无线发射器
+    lore:
+    - 网络无线发射器可以
+    - 将其中的物品传输到绑定的
+    - 网络无线接收器中(只能在同一世界).
+    - 使用网络无线配置器来进行绑定.
+    - 每次传输会消耗 500 J 网络电力.
+  ntw_network_wireless_receiver:
+    name: 网络无线接收器
+    lore:
+    - 网络无线接收器可以
+    - 接收来自绑定的网络无线发射器
+    - 中的物品(只能在同一世界).
+    - 每粘液刻会把接收到的物品
+    - 尝试推送到网络中.
+  ntw_trash:
+    name: 网络清除器
+    lore:
+    - 网络清除器会从网络中
+    - 不断地移除指定物品
+    - 清除的物品会立即消失，谨慎使用!
+  ntw_grid:
+    name: 网格
+    lore:
+    - 网格允许你查看网络中所有的物品
+    - 你也可以直接放入或取出物品
+  ntw_crafting_grid:
+    name: 网格(带合成)
+    lore:
+    - 这种网格与普通网格类似
+    - 但会显示更少的物品
+    - 不过你可以直接使用网络中的物品
+    - 进行合成
+  ntw_cell:
+    name: 网络单元
+    lore:
+    - 网络单元拥有54格空间(相当于一个大箱子)
+    - 可以通过网络访问其中的物品
+    - 也可以直接打开
+  ntw_greedy_block:
+    name: 网络阻断器
+    lore:
+    - 网络阻断器可以设置一个物品,
+    - 然后会从网络各处输入中
+    - 收集指定的物品,最多为1组.
+    - 收集满后,会阻断该物品在网络中的传输,
+    - 任何其他网络方块都不会收到该物品.
+  ntw_quantum_workbench:
+    name: 网络量子工作台
+    lore:
+    - 可以合成量子存储
+  ntw_quantum_storage_1:
+    name: 网络量子存储 (4K)
+    lore:
+    - 可存储 4096 个物品
+    - ''
+    - 在量子奇点中存储大量物品
+  ntw_quantum_storage_2:
+    name: 网络量子存储 (32K)
+    lore:
+    - 可存储 32768 个物品
+    - ''
+    - 在量子奇点中存储大量物品
+  ntw_quantum_storage_3:
+    name: 网络量子存储 (262K)
+    lore:
+    - 可存储 262144 个物品
+    - ''
+    - 在量子奇点中存储大量物品
+  ntw_quantum_storage_4:
+    name: 网络量子存储 (2M)
+    lore:
+    - 可存储 2097152 个物品
+    - ''
+    - 在量子奇点中存储大量物品
+  ntw_quantum_storage_5:
+    name: 网络量子存储 (16M)
+    lore:
+    - 可存储 16777216 个物品
+    - ''
+    - 在量子奇点中存储大量物品
+  ntw_quantum_storage_6:
+    name: 网络量子存储 (134M)
+    lore:
+    - 可存储 134217728 个物品
+    - ''
+    - 在量子奇点中存储大量物品
+  ntw_quantum_storage_7:
+    name: 网络量子存储 (1B)
+    lore:
+    - 可存储 1073741824 个物品
+    - ''
+    - 在量子奇点中存储大量物品
+  ntw_quantum_storage_8:
+    name: 网络量子存储 (∞)
+    lore:
+    - 可存储几乎无限多个物品
+    - ''
+    - 在量子奇点中存储大量物品
+  ntw_capacitor_1:
+    name: 网络电容 (1)
+    lore:
+    - 网络电容可以接收来自
+    - 能源网络的电力并存储起来
+    - 以供其他网络设备使用
+    - ''
+    aditional_lore:
+    - '{0}容量: {1}{2}'
+  ntw_capacitor_2:
+    name: 网络电容 (2)
+    lore:
+    - 网络电容可以接收来自
+    - 能源网络的电力并存储起来
+    - 以供其他网络设备使用
+    - ''
+    aditional_lore:
+    - '{0}容量: {1}{2}'
+  ntw_capacitor_3:
+    name: 网络电容 (3)
+    lore:
+    - 网络电容可以接收来自
+    - 能源网络的电力并存储起来
+    - 以供其他网络设备使用
+    - ''
+    aditional_lore:
+    - '{0}容量: {1}{2}'
+  ntw_capacitor_4:
+    name: 网络电容 (4)
+    lore:
+    - 网络电容可以接收来自
+    - 能源网络的电力并存储起来
+    - 以供其他网络设备使用
+    - ''
+    aditional_lore:
+    - '{0}容量: {1}{2}'
+  ntw_power_outlet_1:
+    name: 网络插口 (1)
+    lore:
+    - 网络插口可以将网络中存储的电力
+    - 传输回电力网络中
+    - 将网络插口理解为发电机
+    - ''
+    - 会有 20% 的损耗.
+    - ''
+    aditional_lore:
+    - '{0}可存储: {1}{2}J'
+  ntw_power_outlet_2:
+    name: 网络插口 (2)
+    lore:
+    - 网络插口可以将网络中存储的电力
+    - 传输回电力网络中.
+    - 将网络插口理解为发电机.
+    - ''
+    - 会有 20% 的损耗.
+    - ''
+    aditional_lore:
+    - '{0}可存储: {1}{2}J'
+  ntw_power_display:
+    name: 网络电表
+    lore:
+    - 网络电表会显示网络中的电力情况
+    - 很简单, 对吧?
+  ntw_recipe_encoder:
+    name: 网络配方编码器
+    lore:
+    - 可以根据输入的物品来制作合成蓝图
+    - ''
+    aditional_lore:
+    - '{0}网络电力消耗: {1}{2} 每次编码'
+  ntw_auto_crafter:
+    name: 网络自动合成机
+    lore:
+    - 网络自动合成机需要合成蓝图才能工作。
+    - 当网络中没有蓝图的目标物品时，
+    - 机器会自动从网络中选取材料进行合成
+    - (需要网络中有足够的原材料)
+    - ''
+    aditional_lore:
+    - '{0}网络电力消耗: {1}{2} 每次合成'
+  ntw_auto_crafter_withholding:
+    name: 网络自动合成机 (预留版)
+    lore:
+    - 网络自动合成机需要合成蓝图才能工作。
+    - 当网络中没有蓝图的目标物品时，
+    - 机器会自动从网络中选取材料进行合成
+    - (需要网络中有足够的原材料)
+    - ''
+    - 预留版的自动合成机会不断进行合成
+    - 直到输出栏拥有1组物品
+    - 这一组物品可以在网络中访问
+    - 也可以通过货运系统取出
+    - ''
+    aditional_lore:
+    - '{0}网络电力消耗: {1}{2} 每次合成'
+  ntw_crafting_blueprint:
+    name: 合成蓝图
+    lore:
+    - 一张空白的蓝图
+    - 可以存储一个合成配方
+    aditional_lore:
+    - ''
+  ntw_probe:
+    name: 网络探测器
+    lore:
+    - 右键点击网络控制器
+    - 可以查看网络中的节点数量
+    aditional_lore:
+    - ''
+  ntw_remote:
+    name: 网络远程访问器
+    lore:
+    - 远程打开绑定的网格
+    - 需要加载网格所在区块
+    - ''
+    aditional_lore:
+    - '{0}Shift+右键点击 {1}普通网格以进行绑定'
+    - '{0}范围: {1}格'
+  ntw_remote_empowered:
+    name: 充能网络远程访问器
+    lore:
+    - 远程打开绑定的网格
+    - 需要加载网格所在区块
+    - ''
+    aditional_lore:
+    - '{0}Shift+右键点击 {1}普通网格以进行绑定'
+    - '{0}范围: {1}格'
+  ntw_remote_pristine:
+    name: 古代网络远程访问器
+    lore:
+    - 远程打开绑定的网格
+    - 需要加载网格所在区块
+    - ''
+    aditional_lore:
+    - '{0}Shift+右键点击 {1}普通网格以进行绑定'
+    - '{0}范围: {1}无限制(仅同一世界)'
+  ntw_remote_ultimate:
+    name: 终极网络远程访问器
+    lore:
+    - 远程打开绑定的网格
+    - 需要加载网格所在区块
+    - ''
+    aditional_lore:
+    - '{0}Shift+右键点击 {1}普通网格以进行绑定'
+    - '{0}范围: {1}跨维度'
+  ntw_crayon:
+    name: 网络绘制器
+    lore:
+    - 当对着网络控制器使用时
+    - 可以让该网络中的方块展示出粒子效果
+    - ''
+    aditional_lore:
+    - ''
+  ntw_configurator:
+    name: 网络配置器
+    lore:
+    - 用于复制网络部件的设置
+    - 可复制带方向选择的网络方块的设置
+    - ''
+    aditional_lore:
+    - '{0}右键点击: {1}应用设置'
+    - '{0}右键点击: {1}存储设置'
+  ntw_wireless_configurator:
+    name: 网络无线配置器
+    lore:
+    - 用于储存一个接收器的位置,
+    - 并设置到发射器中.
+    - ''
+    aditional_lore:
+    - '{0}右键点击: {1}储存接收器的位置'
+    - '{2}Shift+右键点击: {3}将位置设置到发射器中'
+  ntw_rake_1:
+    name: 网络扳手 (1)
+    lore:
+    - 右键点击一个网络节点
+    - 可以立即破坏
+    - ''
+    aditional_lore:
+    - ''
+  ntw_rake_2:
+    name: 网络扳手 (2)
+    lore:
+    - 右键点击一个网络节点
+    - 可以立即破坏
+    - ''
+    aditional_lore:
+    - ''
+  ntw_rake_3:
+    name: 网络扳手 (3)
+    lore:
+    - 右键点击一个网络节点
+    - 可以立即破坏
+    - ''
+    aditional_lore:
+    - ''
+  ntw_debug_stick:
+    name: 网络调试棒
+    lore:
+    - 右键点击一个网络方块开启调试。
+    aditional_lore:
+    - ''
+
+messages:
+  need_guizhanlib_plugin: |
+    "本插件需要 鬼斩前置库插件(GuizhanLibPlugin) 才能运行!"
+    "从此处下载: https://50l.cc/gzlib"
+  need_netheo_plugin_update: 你必须更新下界乌托邦才能让网络添加相关功能。
+  need_slimehud_plugin_update: 你必须更新 SlimeHUD 才能让网络添加相关功能。
+  hand_item_must_quantum_storage: 你必须手持量子存储
+  corrupted_quantum_storage: 量子存储未指定物品或已损坏
+  item_updated: 已更新物品
+  empty: '空'
+  cannot_instantiate_class: Cannot instantiate class
+  none: 无
+  holding: 物品
+  amount: 数量
+  documentation_wiki: 附属 Wiki
+  documentation_wiki_lore:
+  - 点击获取网络的 Wiki 链接
+  click_view_wiki: 单击此处访问Wiki
+  previous_page: 上一页
+  next_page: 下一页
+  change_sorting: 更改排序方式
+  set_filter: 设置过滤器 (右键点击以清除)
+  type_to_filter: 请输入你想要过滤的物品名称(显示名)或类型
+  filter_applied: 已启用过滤器
+  format_amount: '{0}数量: {1}{2}'
+  craft: 合成
+  try_craft: 合成
+  left_click: 左键点击
+  try_return_items: 将合成台内物品送回网络
+  debug_for_item_set_to: 该方块的调试模式已设置为
+  last_restart_off: 该模式将持续至服务器关闭，或者手动关闭。
+  craft_blueprint: 合成蓝图
+  output: 输出
+  output_slot: 输出栏
+  input: 输入
+  already_has_controller: 输出
+  paste_match_template: 粘贴物品模版
+  cut_match_template: 剪切物品模版
+  cut_empty: 留空将剪切任何方块
+  direction: 设置朝向
+  set_direction: 设置朝向
+  open_target_block: 打开目标方块
+  blank_blueprint: 空白蓝图
+  click_to_encode: 点击此处进行编码
+  not_enough_network_power_fulfill_task: 网络中的电力不足，无法完成该任务
+  output_slot_empty: 需要清空输出栏
+  provide_blank_blueprint: 你需要提供一个空的合成蓝图
+  doesnot_look_valid_recipe: 这似乎不是一个有效的配方
+  export_matching: 指定输出物品
+  import_matching: 需要阻断的物品
+  purge_matching: 指定需要清除的物品
+  push_matching: 指定需要推送的物品
+  placement_would_connect_two_controllers: This placement would connect two controllers!
+  status: 状态
+  disconnected: 未连接
+  item_stored: 当前存储的物品
+  no_registered_item: 未指定物品
+  click_icon_to_register0: 拿起物品并点击下方的按钮
+  click_icon_to_register1: 以设置量子存储保存的物品
+  set_item: 设置
+  drag_top_pane_register: 拿起物品并点击这里以设置物品
+  change_void: 切换满载清空输入
+  quantum_empty_before_change: 量子存储必须为空才能更换物品
+  voiding: 满载清空输入
+  click_entangle: 点击进行量子纠缠
+  whildchest_detected: WildChests 已安装
+  whildchest_detected_as_chest: 该方块是否被 WildChest 判断为方块：
+  whildchest_test_failed: WildChest 测试失败！
+  whildchest_test_passed: WildChest 测试通过。
+  received_items: 接收的物品
+  transmit_items_matching: 发送的物品
+  still_cooldown: This is still on cooldown
+  assigned_recipe: 已指定配方
+  nothing: 空
+  outputting: 输出物品
+  debug_op: 该物品只能由 OP 玩家使用。
+  unstack_cards_before: 请单独拿出一张内存卡，不要堆叠
+  cards_cannot_stored: 该物品无法存储至内存卡中
+  cards_must_empty_assign: 只有空内存卡才能分配物品
+  must_target_direcional: 你必须指向一个带方向选择的网络方块
+  directional_not_have_set: 该方块没有指定朝向
+  config_copied: 已复制设置
+  crayon_removed: 已关闭网络绘制
+  crayon_added: 已开启网络绘制
+  network_sumary: '         网络 - 组件统计        '
+  bridges: 网桥
+  monitors: 网络监测器
+  importers: 网络入口
+  exportes: 网络出口
+  grids: 网格
+  cells: 网络单元
+  wipers: 网络内存清除器
+  grabbers: 网络抓取器
+  puschers: 网络粘贴器
+  cutters: 网络剪切器
+  pasters: 网络粘贴器
+  vacuums: 网络吸尘器
+  purgers: 网络清除器
+  crafters: 网络自动合成机
+  power_nodes: 网络能源节点
+  power_outlets: 网络插口
+  power_displays: 网络电表
+  encoders: 网络配方编码器
+  greedy_blocks: 网络阻断器
+  wireless_transmitters: 网络无线发射器
+  wireless_receivers: 网络无线接收器
+  distinct_items: 物品类型数量
+  total_items: 累计物品数量
+  root_power: 总电量
+  total_nodes: 累计节点
+  warning: 警告
+  error: 错误
+  passive: ""
+  notice: "通知"
+  success: "成功"
+  main: "网络"
+  click_info: "单击此处"
+  research: "研究"
+  crafting: "合成材料"
+  machine: "机器"
+  tool: "工具"
+  mechanism: "装置"
+  fuel: "染料"
+  material_class: "材料"
+  recipe_type: "配方类型"
+  guide: "指南"
+  maximum_node_limit: 该网络已达到最大节点数量限制，部分节点可能会无法正常工作。请减少网络节点的数量。
+  set_to_grid: 必须连接到一个网格 (不能是带合成的)
+  bound_to_remote: 网格已绑定至远程访问器
+  bound_not_loaded: 绑定的网格所在区块没有加载
+  bound_not_reach: 绑定的网格不在范围内
+  remote_not_bound: 该远程访问器没有绑定网格
+  bound_not_found: 无法找到绑定的网格
+  must_target_wireless_block: 必须对着网络无线方块使用。
+  no_wireless_been_set: 需要先设置接收器位置。
+  wireless_different_world: 网络无线接收器在不同的世界中。
+  wireless_transmitters_location: 已设置网络无线发射器。
+  wireless_been_set: 已存储网络无线接收器的位置。
+  networks: 网络 (Networks)
+  crafting_materials: 合成材料
+  network_management_tools: 网络管理工具
+  network_items: 网络物品
+  network_quantum_storage_devices: 量子存储设备
+  disabled_items: 已禁用/移除的物品
+  not_supplied: Not supplied
+  successfully_applied: Successfully applied
+  item: Item
+  items: Items
+  item_added_filter: Item added into filter
+  not_enough_item_filter: Not enough items to fill filter
+  no_item_stored_config: No item in stored config
+  no_items_stored_config: No items in stored config
+  unknown_error: 未知/错误
+  current_network_charge: 网络电力


### PR DESCRIPTION
Guys, first I would like to thank you for the huge effort in keeping Slimefun alive. Without you, I don't know if this project would last a few more years.

You are doing a very special job here, congratulations!

I apologize for using Github and not QQGroup, but QQGroup doesn't open here, it keeps loading forever

## The fixed problem:

if you try to open remote controller with a broken grid, `executeAfterLoad` fail becase `blockData` is null

reproduce:

1. do a networks system, controller - grid - some cells
2. bind any remote controller to the grid
3. broke grid
4. try to use remote controller

https://github.com/user-attachments/assets/1a024192-9c3e-4a55-b982-f992bc995dec

## Internacionalization

I made the messages internationalized, including some that haven't been translated into Chinese yet, as you can see here https://github.com/scorninpc/Networks/blob/master/src/main/resources/lang/zh-CN.yml#L637

The entire project can be checked out here https://github.com/scorninpc/Networks

I don't know what you think about this, but I'm very excited to be able to contribute, not only to Networks, but to all the other plugins, if you allow me.