### PR TITLE
fix network remote when break grid

### DIFF
--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkRemote.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkRemote.java
@@ -102,7 +102,7 @@ public class NetworkRemote extends SlimefunItem {
     public static void openGrid(@Nonnull Location location, @Nonnull Player player) {
         SlimefunBlockData blockData = StorageCacheUtils.getBlock(location);
 
-        if(blockData == null) {
+        if (blockData == null) {
             player.sendMessage(Theme.ERROR + "无法找到绑定的网格");
             return;
         }

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkRemote.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkRemote.java
@@ -104,17 +104,17 @@ public class NetworkRemote extends SlimefunItem {
 
         if(blockData == null) {
             player.sendMessage(Theme.ERROR + "无法找到绑定的网格");
+            return;
         }
-        else {
-            StorageCacheUtils.executeAfterLoad(blockData, () -> {
-                if (SlimefunItem.getById(blockData.getSfId()) instanceof NetworkGrid
-                    && Slimefun.getProtectionManager().hasPermission(player, location, Interaction.INTERACT_BLOCK)) {
-                    blockData.getBlockMenu().open(player);
-                } else {
-                    player.sendMessage(Theme.ERROR + "无法找到绑定的网格");
-                }
-            }, false);
-        }
+        
+        StorageCacheUtils.executeAfterLoad(blockData, () -> {
+            if (SlimefunItem.getById(blockData.getSfId()) instanceof NetworkGrid
+                && Slimefun.getProtectionManager().hasPermission(player, location, Interaction.INTERACT_BLOCK)) {
+                blockData.getBlockMenu().open(player);
+            } else {
+                player.sendMessage(Theme.ERROR + "无法找到绑定的网格");
+            }
+        }, false);
     }
 
     public int getRange() {

--- a/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkRemote.java
+++ b/src/main/java/io/github/sefiraat/networks/slimefun/tools/NetworkRemote.java
@@ -101,14 +101,20 @@ public class NetworkRemote extends SlimefunItem {
 
     public static void openGrid(@Nonnull Location location, @Nonnull Player player) {
         SlimefunBlockData blockData = StorageCacheUtils.getBlock(location);
-        StorageCacheUtils.executeAfterLoad(blockData, () -> {
-            if (SlimefunItem.getById(blockData.getSfId()) instanceof NetworkGrid
-                && Slimefun.getProtectionManager().hasPermission(player, location, Interaction.INTERACT_BLOCK)) {
-                blockData.getBlockMenu().open(player);
-            } else {
-                player.sendMessage(Theme.ERROR + "无法找到绑定的网格");
-            }
-        }, false);
+
+        if(blockData == null) {
+            player.sendMessage(Theme.ERROR + "无法找到绑定的网格");
+        }
+        else {
+            StorageCacheUtils.executeAfterLoad(blockData, () -> {
+                if (SlimefunItem.getById(blockData.getSfId()) instanceof NetworkGrid
+                    && Slimefun.getProtectionManager().hasPermission(player, location, Interaction.INTERACT_BLOCK)) {
+                    blockData.getBlockMenu().open(player);
+                } else {
+                    player.sendMessage(Theme.ERROR + "无法找到绑定的网格");
+                }
+            }, false);
+        }
     }
 
     public int getRange() {


### PR DESCRIPTION
When you break grid, the remote fire a error

steps:

- add the network controller, grid, some cells
- register the remote on grid
- break grid
- try use remote

maybe need unregister remote, but this worked fine